### PR TITLE
fix: adapt Kafka MessageBus to two-phase dispose lifecycle

### DIFF
--- a/src/Foundatio.Kafka/Foundatio.Kafka.csproj
+++ b/src/Foundatio.Kafka/Foundatio.Kafka.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.14.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -104,6 +104,7 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
 
         _logger.LogTrace("OnMessage(TopicPartitionOffset={TopicPartitionOffset} GroupId={GroupId})", consumeResult.TopicPartitionOffset, _consumerConfig.GroupId);
 
+        bool shouldAcknowledge = true;
         try
         {
             string? messageType = _options.ResolveMessageType?.Invoke(consumeResult);
@@ -123,10 +124,9 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
             var message = ConvertToMessage(messageType, consumeResult.Message);
             await SendMessageToSubscribersAsync(message).AnyContext();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (IsDisposed)
         {
-            // Bus is disposing — don't commit the offset so the message can be redelivered
-            return;
+            shouldAcknowledge = false;
         }
         catch (MessageBusException)
         {
@@ -137,7 +137,7 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         }
         finally
         {
-            if (!IsDisposed)
+            if (shouldAcknowledge && !IsDisposed)
                 AcknowledgeMessage(consumer, consumeResult);
         }
     }
@@ -302,10 +302,17 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
             {
                 await _listeningTask.WaitAsync(TimeSpan.FromSeconds(15)).AnyContext();
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogTrace(ex, "Listening task cancelled during cleanup");
+            }
             catch (TimeoutException)
             {
                 _logger.LogWarning("Listening task did not complete within timeout during dispose");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error waiting for listening task to complete during cleanup");
             }
         }
 

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -130,9 +130,14 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         }
         catch (MessageBusException)
         {
+            // Subscriber handler failures are application-level errors. The base class
+            // already logged the error. We still commit the offset below to prevent
+            // infinite redelivery loops.
         }
         catch (Exception ex)
         {
+            // Deserialization or message type resolution failed. Log and commit the offset
+            // below to avoid a poison-pill message blocking the consumer indefinitely.
             _logger.LogError(ex, "Error processing message at {TopicPartitionOffset} GroupId={GroupId}, skipping: {Message}", consumeResult.TopicPartitionOffset, _consumerConfig.GroupId, ex.Message);
         }
         finally

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -14,7 +14,7 @@ namespace Foundatio.Messaging;
 
 public interface IKafkaMessageBus : IMessageBus
 {
-    Task DeleteTopicAsync();
+    Task DeleteTopicAsync(CancellationToken cancellationToken = default);
 }
 
 public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMessageBus
@@ -393,9 +393,13 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         }
     }
 
-    async Task IKafkaMessageBus.DeleteTopicAsync()
+    async Task IKafkaMessageBus.DeleteTopicAsync(CancellationToken cancellationToken)
     {
-        using var topicLock = await _lock.LockAsync(DisposedCancellationToken).AnyContext();
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, DisposedCancellationToken);
+        using var topicLock = await _lock.LockAsync(linkedCts.Token).AnyContext();
         using var adminClient = new AdminClientBuilder(_adminClientConfig)
             .SetLogHandler(LogHandler)
             .SetStatisticsHandler(LogStatisticsHandler)

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -95,6 +95,8 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
 
     private async Task OnMessageAsync(IConsumer<string, byte[]> consumer, ConsumeResult<string, byte[]> consumeResult)
     {
+        // No subscribers registered — acknowledge to commit the offset and prevent
+        // the message from being redelivered in an infinite loop.
         if (_subscribers.IsEmpty)
         {
             AcknowledgeMessage(consumer, consumeResult);
@@ -146,6 +148,8 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         }
         finally
         {
+            // Commit the offset unless the bus is disposing, in which case we skip so
+            // the message is redelivered to other consumers in the group.
             if (shouldAcknowledge && !IsDisposed)
                 AcknowledgeMessage(consumer, consumeResult);
         }

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -95,13 +95,11 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
 
     private async Task OnMessageAsync(IConsumer<string, byte[]> consumer, ConsumeResult<string, byte[]> consumeResult)
     {
-        // No subscribers registered — acknowledge to commit the offset and prevent
-        // the message from being redelivered in an infinite loop.
+        // No subscribers registered — skip processing but do NOT commit the offset.
+        // Kafka retains uncommitted messages so they are redelivered once a subscriber
+        // reconnects, which is the expected persistence-guarantee behavior.
         if (_subscribers.IsEmpty)
-        {
-            AcknowledgeMessage(consumer, consumeResult);
             return;
-        }
 
         using var _ = _logger.BeginScope(s => s
             .Property("TopicPartitionOffset", consumeResult.TopicPartitionOffset)

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -26,7 +26,6 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
     private readonly AsyncLock _lock = new();
     private readonly AsyncManualResetEvent _consumerReady = new();
     private bool _topicCreated;
-    private bool _isDisposed;
 
     public KafkaMessageBus(KafkaMessageBusOptions options) : base(options)
     {
@@ -124,21 +123,21 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
             var message = ConvertToMessage(messageType, consumeResult.Message);
             await SendMessageToSubscribersAsync(message).AnyContext();
         }
+        catch (OperationCanceledException)
+        {
+            // Bus is disposing — don't commit the offset so the message can be redelivered
+            return;
+        }
         catch (MessageBusException)
         {
-            // Subscriber handler failures are application-level errors. The base class
-            // already logged the error. We still commit the offset below to prevent
-            // infinite redelivery loops.
         }
         catch (Exception ex)
         {
-            // Deserialization or message type resolution failed. Log and commit the offset
-            // below to avoid a poison-pill message blocking the consumer indefinitely.
             _logger.LogError(ex, "Error processing message at {TopicPartitionOffset} GroupId={GroupId}, skipping: {Message}", consumeResult.TopicPartitionOffset, _consumerConfig.GroupId, ex.Message);
         }
         finally
         {
-            if (!_subscribers.IsEmpty)
+            if (!IsDisposed)
                 AcknowledgeMessage(consumer, consumeResult);
         }
     }
@@ -295,23 +294,26 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         }, DisposedCancellationToken);
     }
 
-    public override void Dispose()
+    protected override async Task CleanupAsync()
     {
-        if (_isDisposed)
+        if (_listeningTask is not null)
         {
-            _logger.LogTrace("MessageBus {MessageBusId} dispose was already called", MessageBusId);
-            return;
+            try
+            {
+                await _listeningTask.WaitAsync(TimeSpan.FromSeconds(15)).AnyContext();
+            }
+            catch (OperationCanceledException) { }
+            catch (TimeoutException)
+            {
+                _logger.LogWarning("Listening task did not complete within timeout during dispose");
+            }
         }
-
-        _isDisposed = true;
-        _logger.LogTrace("MessageBus {MessageBusId} dispose", MessageBusId);
 
         int? queueSize = _producer?.Flush(TimeSpan.FromSeconds(15));
         if (queueSize > 0)
             _logger.LogTrace("Flushed producer {queueSize}", queueSize);
 
         _producer?.Dispose();
-        base.Dispose();
     }
 
     private async Task EnsureTopicCreatedAsync()

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -96,7 +96,10 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
     private async Task OnMessageAsync(IConsumer<string, byte[]> consumer, ConsumeResult<string, byte[]> consumeResult)
     {
         if (_subscribers.IsEmpty)
+        {
+            AcknowledgeMessage(consumer, consumeResult);
             return;
+        }
 
         using var _ = _logger.BeginScope(s => s
             .Property("TopicPartitionOffset", consumeResult.TopicPartitionOffset)
@@ -126,6 +129,7 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         }
         catch (OperationCanceledException) when (IsDisposed)
         {
+            // Bus is disposing — skip offset commit so the message is redelivered to other consumers
             shouldAcknowledge = false;
         }
         catch (MessageBusException)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTestBase.cs
+++ b/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTestBase.cs
@@ -43,7 +43,9 @@ public class KafkaMessageBusTestBase : MessageBusTestBase
             {
                 await kafkaMessageBus.DeleteTopicAsync();
             }
-            catch (ObjectDisposedException) { }
+            catch (ObjectDisposedException)
+            {
+            }
         }
 
         await base.CleanupMessageBusAsync(messageBus);

--- a/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTestBase.cs
+++ b/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTestBase.cs
@@ -38,7 +38,13 @@ public class KafkaMessageBusTestBase : MessageBusTestBase
     protected override async Task CleanupMessageBusAsync(IMessageBus messageBus)
     {
         if (EnableTopicDeletion && messageBus is IKafkaMessageBus kafkaMessageBus)
-            await kafkaMessageBus.DeleteTopicAsync();
+        {
+            try
+            {
+                await kafkaMessageBus.DeleteTopicAsync();
+            }
+            catch (ObjectDisposedException) { }
+        }
 
         await base.CleanupMessageBusAsync(messageBus);
     }

--- a/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
+++ b/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
@@ -45,21 +45,9 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
-    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    public override Task CanSendMappedMessageAsync()
     {
-        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
-    {
-        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
+        return base.CanSendMappedMessageAsync();
     }
 
     [Fact]
@@ -123,6 +111,12 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
+    public override Task CanHandlePoisonedMessageAsync()
+    {
+        return base.CanHandlePoisonedMessageAsync();
+    }
+
+    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
@@ -147,6 +141,24 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
+    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    {
+        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
+    {
+        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
+    {
+        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+    }
+
+    [Fact]
     public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
         return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
@@ -159,21 +171,9 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
-    public override Task CanHandlePoisonedMessageAsync()
+    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
-        return base.CanHandlePoisonedMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
-    {
-        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
     }
 
     [Fact]
@@ -183,9 +183,9 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
-    public override Task CanSendMappedMessageAsync()
+    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
     {
-        return base.CanSendMappedMessageAsync();
+        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
+++ b/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
@@ -123,6 +123,42 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
+    public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
     public override Task CanHandlePoisonedMessageAsync()
     {
         return base.CanHandlePoisonedMessageAsync();

--- a/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
+++ b/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
@@ -117,9 +117,9 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
     }
 
     [Fact]
-    public override void CanDisposeWithNoSubscribersOrPublishers()
+    public override Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        base.CanDisposeWithNoSubscribersOrPublishers();
+        return base.CanDisposeWithNoSubscribersOrPublishersAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add \CleanupAsync\ override to await listener task, flush and dispose producer
- Handle \OperationCanceledException\ in \OnMessageAsync\ to skip offset commit (message redelivered)
- Guard offset commit with \IsDisposed\ to prevent committing during shutdown
- Remove ad-hoc Dispose override and shadowed \_isDisposed\

## Dependencies
- Depends on FoundatioFx/Foundatio#492 (core two-phase dispose)

## Test plan
- [x] Builds with local Foundatio source (\ReferenceFoundatioSource=true\)
- [ ] CI runs integration tests with Kafka