### PR TITLE
feat: align Kafka config with Confluent.Kafka 2.14.2, fix concurrency

### DIFF
--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -25,7 +25,7 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
     private readonly IProducer<string, byte[]> _producer;
     private readonly AsyncLock _lock = new();
     private readonly AsyncManualResetEvent _consumerReady = new();
-    private bool _topicCreated;
+    private volatile bool _topicCreated;
 
     public KafkaMessageBus(KafkaMessageBusOptions options) : base(options)
     {
@@ -229,80 +229,83 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         if (DisposedCancellationToken.IsCancellationRequested)
             return;
 
-        if (_listeningTask is { IsCompleted: false })
+        using (_lock.Lock())
         {
-            _logger.LogTrace("Already Listening: {Topic}", _options.Topic);
-            return;
-        }
-
-        _logger.LogTrace("Start Listening: {Topic}", _options.Topic);
-
-        _listeningTask = Task.Run(async () =>
-        {
-            while (!DisposedCancellationToken.IsCancellationRequested)
+            if (_listeningTask is { IsCompleted: false })
             {
-                using var consumer = new ConsumerBuilder<string, byte[]>(_consumerConfig)
-                    .SetLogHandler(LogHandler)
-                    .SetStatisticsHandler(LogStatisticsHandler)
-                    .SetErrorHandler(LogErrorHandler)
-                    .SetPartitionsAssignedHandler(LogPartitionAssignmentHandler)
-                    .SetPartitionsLostHandler(LogPartitionsLostHandler)
-                    .SetPartitionsRevokedHandler(LogPartitionsRevokedHandler)
-                    .SetOffsetsCommittedHandler(LogOffsetsCommittedHandler)
-                    .SetOAuthBearerTokenRefreshHandler(LogOAuthBearerTokenRefreshHandler)
-                    .Build();
+                _logger.LogTrace("Already Listening: {Topic}", _options.Topic);
+                return;
+            }
 
-                try
-                {
-                    consumer.Subscribe(_options.Topic);
-                    _logger.LogTrace("Consumer {ConsumerName} subscribed to {Topic} GroupId={GroupId}", consumer.Name, _options.Topic, _consumerConfig.GroupId);
+            _logger.LogTrace("Start Listening: {Topic}", _options.Topic);
 
-                    while (!DisposedCancellationToken.IsCancellationRequested)
-                    {
-                        var consumeResult = consumer.Consume(DisposedCancellationToken);
-                        await OnMessageAsync(consumer, consumeResult).AnyContext();
-                    }
-                }
-                catch (OperationCanceledException)
+            _listeningTask = Task.Run(async () =>
+            {
+                while (!DisposedCancellationToken.IsCancellationRequested)
                 {
-                    // Don't log operation cancelled exceptions
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    if (DisposedCancellationToken.IsCancellationRequested)
-                    {
-                        _logger.LogTrace(ex, "Error consuming {Topic} GroupId={GroupId} during shutdown: {Message}", _options.Topic, _consumerConfig.GroupId, ex.Message);
-                        break;
-                    }
-
-                    _logger.LogError(ex, "Error consuming {Topic} GroupId={GroupId}: {Message}. Retrying in 1s...", _options.Topic, _consumerConfig.GroupId, ex.Message);
+                    using var consumer = new ConsumerBuilder<string, byte[]>(_consumerConfig)
+                        .SetLogHandler(LogHandler)
+                        .SetStatisticsHandler(LogStatisticsHandler)
+                        .SetErrorHandler(LogErrorHandler)
+                        .SetPartitionsAssignedHandler(LogPartitionAssignmentHandler)
+                        .SetPartitionsLostHandler(LogPartitionsLostHandler)
+                        .SetPartitionsRevokedHandler(LogPartitionsRevokedHandler)
+                        .SetOffsetsCommittedHandler(LogOffsetsCommittedHandler)
+                        .SetOAuthBearerTokenRefreshHandler(LogOAuthBearerTokenRefreshHandler)
+                        .Build();
 
                     try
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(1), _timeProvider, DisposedCancellationToken).AnyContext();
+                        consumer.Subscribe(_options.Topic);
+                        _logger.LogTrace("Consumer {ConsumerName} subscribed to {Topic} GroupId={GroupId}", consumer.Name, _options.Topic, _consumerConfig.GroupId);
+
+                        while (!DisposedCancellationToken.IsCancellationRequested)
+                        {
+                            var consumeResult = consumer.Consume(DisposedCancellationToken);
+                            await OnMessageAsync(consumer, consumeResult).AnyContext();
+                        }
                     }
                     catch (OperationCanceledException)
                     {
+                        // Don't log operation cancelled exceptions
                         break;
-                    }
-                }
-                finally
-                {
-                    try
-                    {
-                        consumer.Unsubscribe();
-                        consumer.Close();
-
-                        _logger.LogTrace("Consumer {ConsumerName} unsubscribed from {Topic} GroupId={GroupId}", consumer.Name, _options.Topic, _consumerConfig.GroupId);
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogTrace(ex, "Error cleaning up consumer for {Topic} GroupId={GroupId}: {Message}", _options.Topic, _consumerConfig.GroupId, ex.Message);
+                        if (DisposedCancellationToken.IsCancellationRequested)
+                        {
+                            _logger.LogTrace(ex, "Error consuming {Topic} GroupId={GroupId} during shutdown: {Message}", _options.Topic, _consumerConfig.GroupId, ex.Message);
+                            break;
+                        }
+
+                        _logger.LogError(ex, "Error consuming {Topic} GroupId={GroupId}: {Message}. Retrying in 1s...", _options.Topic, _consumerConfig.GroupId, ex.Message);
+
+                        try
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(1), _timeProvider, DisposedCancellationToken).AnyContext();
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            consumer.Unsubscribe();
+                            consumer.Close();
+
+                            _logger.LogTrace("Consumer {ConsumerName} unsubscribed from {Topic} GroupId={GroupId}", consumer.Name, _options.Topic, _consumerConfig.GroupId);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogTrace(ex, "Error cleaning up consumer for {Topic} GroupId={GroupId}: {Message}", _options.Topic, _consumerConfig.GroupId, ex.Message);
+                        }
                     }
                 }
-            }
-        }, DisposedCancellationToken);
+            }, DisposedCancellationToken);
+        }
     }
 
     protected override async Task CleanupAsync()
@@ -480,7 +483,7 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
 
     private void LogOAuthBearerTokenRefreshHandler(IClient client, string token)
     {
-        _logger.LogTrace("Client refresh OAuth Bearer Token: {BearerToken}", token);
+        _logger.LogTrace("Client OAuth Bearer Token refresh requested");
     }
 
     private void LogErrorHandler(IClient client, Error error)
@@ -491,72 +494,102 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
     private ClientConfig CreateClientConfig()
     {
         var clientConfig = new ClientConfig();
-        if (!String.IsNullOrEmpty(_options.ClientId)) clientConfig.ClientId = _options.ClientId;
+        if (_options.Acks.HasValue) clientConfig.Acks = _options.Acks;
+        if (_options.ApiVersionFallbackMs.HasValue) clientConfig.ApiVersionFallbackMs = _options.ApiVersionFallbackMs;
+        if (_options.ApiVersionRequest.HasValue) clientConfig.ApiVersionRequest = _options.ApiVersionRequest;
+        if (_options.ApiVersionRequestTimeoutMs.HasValue) clientConfig.ApiVersionRequestTimeoutMs = _options.ApiVersionRequestTimeoutMs;
         if (!String.IsNullOrEmpty(_options.BootstrapServers)) clientConfig.BootstrapServers = _options.BootstrapServers;
-        if (!String.IsNullOrEmpty(_options.TopicBlacklist)) clientConfig.TopicBlacklist = _options.TopicBlacklist;
+        if (_options.BrokerAddressFamily.HasValue) clientConfig.BrokerAddressFamily = _options.BrokerAddressFamily;
+        if (_options.BrokerAddressTtl.HasValue) clientConfig.BrokerAddressTtl = _options.BrokerAddressTtl;
+        if (!String.IsNullOrEmpty(_options.BrokerVersionFallback)) clientConfig.BrokerVersionFallback = _options.BrokerVersionFallback;
+        if (_options.ClientDnsLookup.HasValue) clientConfig.ClientDnsLookup = _options.ClientDnsLookup;
+        if (!String.IsNullOrEmpty(_options.ClientId)) clientConfig.ClientId = _options.ClientId;
+        if (!String.IsNullOrEmpty(_options.ClientRack)) clientConfig.ClientRack = _options.ClientRack;
+        if (_options.ConnectionsMaxIdleMs.HasValue) clientConfig.ConnectionsMaxIdleMs = _options.ConnectionsMaxIdleMs;
         if (!String.IsNullOrEmpty(_options.Debug)) clientConfig.Debug = _options.Debug;
+        if (_options.EnableMetricsPush.HasValue) clientConfig.EnableMetricsPush = _options.EnableMetricsPush;
+        if (_options.EnableRandomSeed.HasValue) clientConfig.EnableRandomSeed = _options.EnableRandomSeed;
+        if (_options.EnableSaslOauthbearerUnsecureJwt.HasValue) clientConfig.EnableSaslOauthbearerUnsecureJwt = _options.EnableSaslOauthbearerUnsecureJwt;
+        if (_options.EnableSslCertificateVerification.HasValue) clientConfig.EnableSslCertificateVerification = _options.EnableSslCertificateVerification;
+        if (!String.IsNullOrEmpty(_options.HttpsCaLocation)) clientConfig.HttpsCaLocation = _options.HttpsCaLocation;
+        if (!String.IsNullOrEmpty(_options.HttpsCaPem)) clientConfig.HttpsCaPem = _options.HttpsCaPem;
+        if (_options.InternalTerminationSignal.HasValue) clientConfig.InternalTerminationSignal = _options.InternalTerminationSignal;
+        if (_options.LogConnectionClose.HasValue) clientConfig.LogConnectionClose = _options.LogConnectionClose;
+        if (_options.LogQueue.HasValue) clientConfig.LogQueue = _options.LogQueue;
+        if (_options.LogThreadName.HasValue) clientConfig.LogThreadName = _options.LogThreadName;
+        if (_options.MaxInFlight.HasValue) clientConfig.MaxInFlight = _options.MaxInFlight;
+        if (_options.MessageCopyMaxBytes.HasValue) clientConfig.MessageCopyMaxBytes = _options.MessageCopyMaxBytes;
+        if (_options.MessageMaxBytes.HasValue) clientConfig.MessageMaxBytes = _options.MessageMaxBytes;
+        if (_options.MetadataMaxAgeMs.HasValue) clientConfig.MetadataMaxAgeMs = _options.MetadataMaxAgeMs;
+        if (_options.MetadataRecoveryRebootstrapTriggerMs.HasValue) clientConfig.MetadataRecoveryRebootstrapTriggerMs = _options.MetadataRecoveryRebootstrapTriggerMs;
+        if (_options.MetadataRecoveryStrategy.HasValue) clientConfig.MetadataRecoveryStrategy = _options.MetadataRecoveryStrategy;
+        if (!String.IsNullOrEmpty(_options.PluginLibraryPaths)) clientConfig.PluginLibraryPaths = _options.PluginLibraryPaths;
+        if (_options.ReceiveMessageMaxBytes.HasValue) clientConfig.ReceiveMessageMaxBytes = _options.ReceiveMessageMaxBytes;
+        if (_options.ReconnectBackoffMaxMs.HasValue) clientConfig.ReconnectBackoffMaxMs = _options.ReconnectBackoffMaxMs;
+        if (_options.ReconnectBackoffMs.HasValue) clientConfig.ReconnectBackoffMs = _options.ReconnectBackoffMs;
+        if (_options.RetryBackoffMaxMs.HasValue) clientConfig.RetryBackoffMaxMs = _options.RetryBackoffMaxMs;
+        if (!String.IsNullOrEmpty(_options.SaslKerberosKeytab)) clientConfig.SaslKerberosKeytab = _options.SaslKerberosKeytab;
+        if (!String.IsNullOrEmpty(_options.SaslKerberosKinitCmd)) clientConfig.SaslKerberosKinitCmd = _options.SaslKerberosKinitCmd;
+        if (_options.SaslKerberosMinTimeBeforeRelogin.HasValue) clientConfig.SaslKerberosMinTimeBeforeRelogin = _options.SaslKerberosMinTimeBeforeRelogin;
+        if (!String.IsNullOrEmpty(_options.SaslKerberosPrincipal)) clientConfig.SaslKerberosPrincipal = _options.SaslKerberosPrincipal;
+        if (!String.IsNullOrEmpty(_options.SaslKerberosServiceName)) clientConfig.SaslKerberosServiceName = _options.SaslKerberosServiceName;
+        if (_options.SaslMechanism.HasValue) clientConfig.SaslMechanism = _options.SaslMechanism;
+        if (_options.SaslOauthbearerAssertionAlgorithm.HasValue) clientConfig.SaslOauthbearerAssertionAlgorithm = _options.SaslOauthbearerAssertionAlgorithm;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionClaimAud)) clientConfig.SaslOauthbearerAssertionClaimAud = _options.SaslOauthbearerAssertionClaimAud;
+        if (_options.SaslOauthbearerAssertionClaimExpSeconds.HasValue) clientConfig.SaslOauthbearerAssertionClaimExpSeconds = _options.SaslOauthbearerAssertionClaimExpSeconds;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionClaimIss)) clientConfig.SaslOauthbearerAssertionClaimIss = _options.SaslOauthbearerAssertionClaimIss;
+        if (_options.SaslOauthbearerAssertionClaimJtiInclude.HasValue) clientConfig.SaslOauthbearerAssertionClaimJtiInclude = _options.SaslOauthbearerAssertionClaimJtiInclude;
+        if (_options.SaslOauthbearerAssertionClaimNbfSeconds.HasValue) clientConfig.SaslOauthbearerAssertionClaimNbfSeconds = _options.SaslOauthbearerAssertionClaimNbfSeconds;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionClaimSub)) clientConfig.SaslOauthbearerAssertionClaimSub = _options.SaslOauthbearerAssertionClaimSub;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionFile)) clientConfig.SaslOauthbearerAssertionFile = _options.SaslOauthbearerAssertionFile;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionJwtTemplateFile)) clientConfig.SaslOauthbearerAssertionJwtTemplateFile = _options.SaslOauthbearerAssertionJwtTemplateFile;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionPrivateKeyFile)) clientConfig.SaslOauthbearerAssertionPrivateKeyFile = _options.SaslOauthbearerAssertionPrivateKeyFile;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionPrivateKeyPassphrase)) clientConfig.SaslOauthbearerAssertionPrivateKeyPassphrase = _options.SaslOauthbearerAssertionPrivateKeyPassphrase;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerAssertionPrivateKeyPem)) clientConfig.SaslOauthbearerAssertionPrivateKeyPem = _options.SaslOauthbearerAssertionPrivateKeyPem;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerClientId)) clientConfig.SaslOauthbearerClientId = _options.SaslOauthbearerClientId;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerClientSecret)) clientConfig.SaslOauthbearerClientSecret = _options.SaslOauthbearerClientSecret;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerConfig)) clientConfig.SaslOauthbearerConfig = _options.SaslOauthbearerConfig;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerExtensions)) clientConfig.SaslOauthbearerExtensions = _options.SaslOauthbearerExtensions;
+        if (_options.SaslOauthbearerGrantType.HasValue) clientConfig.SaslOauthbearerGrantType = _options.SaslOauthbearerGrantType;
+        if (_options.SaslOauthbearerMetadataAuthenticationType.HasValue) clientConfig.SaslOauthbearerMetadataAuthenticationType = _options.SaslOauthbearerMetadataAuthenticationType;
+        if (_options.SaslOauthbearerMethod.HasValue) clientConfig.SaslOauthbearerMethod = _options.SaslOauthbearerMethod;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerScope)) clientConfig.SaslOauthbearerScope = _options.SaslOauthbearerScope;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerSubClaimName)) clientConfig.SaslOauthbearerSubClaimName = _options.SaslOauthbearerSubClaimName;
+        if (!String.IsNullOrEmpty(_options.SaslOauthbearerTokenEndpointUrl)) clientConfig.SaslOauthbearerTokenEndpointUrl = _options.SaslOauthbearerTokenEndpointUrl;
+        if (!String.IsNullOrEmpty(_options.SaslPassword)) clientConfig.SaslPassword = _options.SaslPassword;
+        if (!String.IsNullOrEmpty(_options.SaslUsername)) clientConfig.SaslUsername = _options.SaslUsername;
+        if (_options.SecurityProtocol.HasValue) clientConfig.SecurityProtocol = _options.SecurityProtocol;
+        if (_options.SocketConnectionSetupTimeoutMs.HasValue) clientConfig.SocketConnectionSetupTimeoutMs = _options.SocketConnectionSetupTimeoutMs;
+        if (_options.SocketKeepaliveEnable.HasValue) clientConfig.SocketKeepaliveEnable = _options.SocketKeepaliveEnable;
+        if (_options.SocketMaxFails.HasValue) clientConfig.SocketMaxFails = _options.SocketMaxFails;
+        if (_options.SocketNagleDisable.HasValue) clientConfig.SocketNagleDisable = _options.SocketNagleDisable;
+        if (_options.SocketReceiveBufferBytes.HasValue) clientConfig.SocketReceiveBufferBytes = _options.SocketReceiveBufferBytes;
+        if (_options.SocketSendBufferBytes.HasValue) clientConfig.SocketSendBufferBytes = _options.SocketSendBufferBytes;
+        if (_options.SocketTimeoutMs.HasValue) clientConfig.SocketTimeoutMs = _options.SocketTimeoutMs;
+        if (!String.IsNullOrEmpty(_options.SslCaCertificateStores)) clientConfig.SslCaCertificateStores = _options.SslCaCertificateStores;
+        if (!String.IsNullOrEmpty(_options.SslCaLocation)) clientConfig.SslCaLocation = _options.SslCaLocation;
+        if (!String.IsNullOrEmpty(_options.SslCaPem)) clientConfig.SslCaPem = _options.SslCaPem;
+        if (!String.IsNullOrEmpty(_options.SslCertificateLocation)) clientConfig.SslCertificateLocation = _options.SslCertificateLocation;
+        if (!String.IsNullOrEmpty(_options.SslCertificatePem)) clientConfig.SslCertificatePem = _options.SslCertificatePem;
         if (!String.IsNullOrEmpty(_options.SslCipherSuites)) clientConfig.SslCipherSuites = _options.SslCipherSuites;
+        if (!String.IsNullOrEmpty(_options.SslCrlLocation)) clientConfig.SslCrlLocation = _options.SslCrlLocation;
         if (!String.IsNullOrEmpty(_options.SslCurvesList)) clientConfig.SslCurvesList = _options.SslCurvesList;
-        if (!String.IsNullOrEmpty(_options.SslSigalgsList)) clientConfig.SslSigalgsList = _options.SslSigalgsList;
+        if (_options.SslEndpointIdentificationAlgorithm.HasValue) clientConfig.SslEndpointIdentificationAlgorithm = _options.SslEndpointIdentificationAlgorithm;
+        if (!String.IsNullOrEmpty(_options.SslEngineId)) clientConfig.SslEngineId = _options.SslEngineId;
+        if (!String.IsNullOrEmpty(_options.SslEngineLocation)) clientConfig.SslEngineLocation = _options.SslEngineLocation;
         if (!String.IsNullOrEmpty(_options.SslKeyLocation)) clientConfig.SslKeyLocation = _options.SslKeyLocation;
         if (!String.IsNullOrEmpty(_options.SslKeyPassword)) clientConfig.SslKeyPassword = _options.SslKeyPassword;
         if (!String.IsNullOrEmpty(_options.SslKeyPem)) clientConfig.SslKeyPem = _options.SslKeyPem;
-        if (!String.IsNullOrEmpty(_options.SslCertificateLocation)) clientConfig.SslCertificateLocation = _options.SslCertificateLocation;
-        if (!String.IsNullOrEmpty(_options.SslCertificatePem)) clientConfig.SslCertificatePem = _options.SslCertificatePem;
-        if (!String.IsNullOrEmpty(_options.SslCaLocation)) clientConfig.SslCaLocation = _options.SslCaLocation;
-        if (!String.IsNullOrEmpty(_options.SslCaPem)) clientConfig.SslCaPem = _options.SslCaPem;
-        if (!String.IsNullOrEmpty(_options.SslCaCertificateStores)) clientConfig.SslCaCertificateStores = _options.SslCaCertificateStores;
-        if (!String.IsNullOrEmpty(_options.SslCrlLocation)) clientConfig.SslCrlLocation = _options.SslCrlLocation;
         if (!String.IsNullOrEmpty(_options.SslKeystoreLocation)) clientConfig.SslKeystoreLocation = _options.SslKeystoreLocation;
         if (!String.IsNullOrEmpty(_options.SslKeystorePassword)) clientConfig.SslKeystorePassword = _options.SslKeystorePassword;
-        if (!String.IsNullOrEmpty(_options.SslEngineLocation)) clientConfig.SslEngineLocation = _options.SslEngineLocation;
-        if (!String.IsNullOrEmpty(_options.SslEngineId)) clientConfig.SslEngineId = _options.SslEngineId;
-        if (!String.IsNullOrEmpty(_options.BrokerVersionFallback)) clientConfig.BrokerVersionFallback = _options.BrokerVersionFallback;
-        if (!String.IsNullOrEmpty(_options.SaslKerberosServiceName)) clientConfig.SaslKerberosServiceName = _options.SaslKerberosServiceName;
-        if (!String.IsNullOrEmpty(_options.SaslKerberosPrincipal)) clientConfig.SaslKerberosPrincipal = _options.SaslKerberosPrincipal;
-        if (!String.IsNullOrEmpty(_options.SaslKerberosKinitCmd)) clientConfig.SaslKerberosKinitCmd = _options.SaslKerberosKinitCmd;
-        if (!String.IsNullOrEmpty(_options.SaslKerberosKeytab)) clientConfig.SaslKerberosKeytab = _options.SaslKerberosKeytab;
-        if (!String.IsNullOrEmpty(_options.SaslUsername)) clientConfig.SaslUsername = _options.SaslUsername;
-        if (!String.IsNullOrEmpty(_options.SaslPassword)) clientConfig.SaslPassword = _options.SaslPassword;
-        if (!String.IsNullOrEmpty(_options.SaslOauthbearerConfig)) clientConfig.SaslOauthbearerConfig = _options.SaslOauthbearerConfig;
-        if (!String.IsNullOrEmpty(_options.PluginLibraryPaths)) clientConfig.PluginLibraryPaths = _options.PluginLibraryPaths;
-        if (!String.IsNullOrEmpty(_options.ClientRack)) clientConfig.ClientRack = _options.ClientRack;
-        if (_options.SaslMechanism.HasValue) clientConfig.SaslMechanism = _options.SaslMechanism;
-        if (_options.Acks.HasValue) clientConfig.Acks = _options.Acks;
-        if (_options.MessageMaxBytes.HasValue) clientConfig.MessageMaxBytes = _options.MessageMaxBytes;
-        if (_options.MessageCopyMaxBytes.HasValue) clientConfig.MessageCopyMaxBytes = _options.MessageCopyMaxBytes;
-        if (_options.ReceiveMessageMaxBytes.HasValue) clientConfig.ReceiveMessageMaxBytes = _options.ReceiveMessageMaxBytes;
-        if (_options.MaxInFlight.HasValue) clientConfig.MaxInFlight = _options.MaxInFlight;
-        if (_options.TopicMetadataRefreshIntervalMs.HasValue) clientConfig.TopicMetadataRefreshIntervalMs = _options.TopicMetadataRefreshIntervalMs;
-        if (_options.MetadataMaxAgeMs.HasValue) clientConfig.MetadataMaxAgeMs = _options.MetadataMaxAgeMs;
-        if (_options.TopicMetadataRefreshFastIntervalMs.HasValue) clientConfig.TopicMetadataRefreshFastIntervalMs = _options.TopicMetadataRefreshFastIntervalMs;
-        if (_options.TopicMetadataRefreshSparse.HasValue) clientConfig.TopicMetadataRefreshSparse = _options.TopicMetadataRefreshSparse;
-        if (_options.TopicMetadataPropagationMaxMs.HasValue) clientConfig.TopicMetadataPropagationMaxMs = _options.TopicMetadataPropagationMaxMs;
-        if (_options.SocketTimeoutMs.HasValue) clientConfig.SocketTimeoutMs = _options.SocketTimeoutMs;
-        if (_options.SocketSendBufferBytes.HasValue) clientConfig.SocketSendBufferBytes = _options.SocketSendBufferBytes;
-        if (_options.SocketReceiveBufferBytes.HasValue) clientConfig.SocketReceiveBufferBytes = _options.SocketReceiveBufferBytes;
-        if (_options.SocketKeepaliveEnable.HasValue) clientConfig.SocketKeepaliveEnable = _options.SocketKeepaliveEnable;
-        if (_options.SocketNagleDisable.HasValue) clientConfig.SocketNagleDisable = _options.SocketNagleDisable;
-        if (_options.SocketMaxFails.HasValue) clientConfig.SocketMaxFails = _options.SocketMaxFails;
-        if (_options.BrokerAddressTtl.HasValue) clientConfig.BrokerAddressTtl = _options.BrokerAddressTtl;
-        if (_options.BrokerAddressFamily.HasValue) clientConfig.BrokerAddressFamily = _options.BrokerAddressFamily;
-        if (_options.ConnectionsMaxIdleMs.HasValue) clientConfig.ConnectionsMaxIdleMs = _options.ConnectionsMaxIdleMs;
-        if (_options.ReconnectBackoffMs.HasValue) clientConfig.ReconnectBackoffMs = _options.ReconnectBackoffMs;
-        if (_options.ReconnectBackoffMaxMs.HasValue) clientConfig.ReconnectBackoffMaxMs = _options.ReconnectBackoffMaxMs;
+        if (!String.IsNullOrEmpty(_options.SslProviders)) clientConfig.SslProviders = _options.SslProviders;
+        if (!String.IsNullOrEmpty(_options.SslSigalgsList)) clientConfig.SslSigalgsList = _options.SslSigalgsList;
         if (_options.StatisticsIntervalMs.HasValue) clientConfig.StatisticsIntervalMs = _options.StatisticsIntervalMs;
-        if (_options.LogQueue.HasValue) clientConfig.LogQueue = _options.LogQueue;
-        if (_options.LogThreadName.HasValue) clientConfig.LogThreadName = _options.LogThreadName;
-        if (_options.EnableRandomSeed.HasValue) clientConfig.EnableRandomSeed = _options.EnableRandomSeed;
-        if (_options.LogConnectionClose.HasValue) clientConfig.LogConnectionClose = _options.LogConnectionClose;
-        if (_options.InternalTerminationSignal.HasValue) clientConfig.InternalTerminationSignal = _options.InternalTerminationSignal;
-        if (_options.ApiVersionRequest.HasValue) clientConfig.ApiVersionRequest = _options.ApiVersionRequest;
-        if (_options.ApiVersionRequestTimeoutMs.HasValue) clientConfig.ApiVersionRequestTimeoutMs = _options.ApiVersionRequestTimeoutMs;
-        if (_options.ApiVersionFallbackMs.HasValue) clientConfig.ApiVersionFallbackMs = _options.ApiVersionFallbackMs;
-        if (_options.SecurityProtocol.HasValue) clientConfig.SecurityProtocol = _options.SecurityProtocol;
-        if (_options.EnableSslCertificateVerification.HasValue) clientConfig.EnableSslCertificateVerification = _options.EnableSslCertificateVerification;
-        if (_options.SslEndpointIdentificationAlgorithm.HasValue) clientConfig.SslEndpointIdentificationAlgorithm = _options.SslEndpointIdentificationAlgorithm;
-        if (_options.SaslKerberosMinTimeBeforeRelogin.HasValue) clientConfig.SaslKerberosMinTimeBeforeRelogin = _options.SaslKerberosMinTimeBeforeRelogin;
-        if (_options.EnableSaslOauthbearerUnsecureJwt.HasValue) clientConfig.EnableSaslOauthbearerUnsecureJwt = _options.EnableSaslOauthbearerUnsecureJwt;
+        if (!String.IsNullOrEmpty(_options.TopicBlacklist)) clientConfig.TopicBlacklist = _options.TopicBlacklist;
+        if (_options.TopicMetadataPropagationMaxMs.HasValue) clientConfig.TopicMetadataPropagationMaxMs = _options.TopicMetadataPropagationMaxMs;
+        if (_options.TopicMetadataRefreshFastIntervalMs.HasValue) clientConfig.TopicMetadataRefreshFastIntervalMs = _options.TopicMetadataRefreshFastIntervalMs;
+        if (_options.TopicMetadataRefreshIntervalMs.HasValue) clientConfig.TopicMetadataRefreshIntervalMs = _options.TopicMetadataRefreshIntervalMs;
+        if (_options.TopicMetadataRefreshSparse.HasValue) clientConfig.TopicMetadataRefreshSparse = _options.TopicMetadataRefreshSparse;
 
         return clientConfig;
     }
@@ -571,29 +604,27 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
     {
         var clientConfig = CreateClientConfig();
         var producerConfig = new ProducerConfig(clientConfig);
-
-        // TODO: Producer config throws exception with this property
-        if (!String.IsNullOrEmpty(_options.DeliveryReportFields)) producerConfig.DeliveryReportFields = _options.DeliveryReportFields;
-        if (!String.IsNullOrEmpty(_options.TransactionalId)) producerConfig.TransactionalId = _options.TransactionalId;
-        if (_options.EnableBackgroundPoll.HasValue) producerConfig.EnableBackgroundPoll = _options.EnableBackgroundPoll;
-        if (_options.EnableDeliveryReports.HasValue) producerConfig.EnableDeliveryReports = _options.EnableDeliveryReports;
-        if (_options.RequestTimeoutMs.HasValue) producerConfig.RequestTimeoutMs = _options.RequestTimeoutMs;
-        if (_options.MessageTimeoutMs.HasValue) producerConfig.MessageTimeoutMs = _options.MessageTimeoutMs;
-        if (_options.Partitioner.HasValue) producerConfig.Partitioner = _options.Partitioner;
-        if (_options.CompressionLevel.HasValue) producerConfig.CompressionLevel = _options.CompressionLevel;
-        if (_options.TransactionTimeoutMs.HasValue) producerConfig.TransactionTimeoutMs = _options.TransactionTimeoutMs;
-        if (_options.EnableIdempotence.HasValue) producerConfig.EnableIdempotence = _options.EnableIdempotence;
-        if (_options.EnableGaplessGuarantee.HasValue) producerConfig.EnableGaplessGuarantee = _options.EnableGaplessGuarantee;
-        if (_options.QueueBufferingMaxMessages.HasValue) producerConfig.QueueBufferingMaxMessages = _options.QueueBufferingMaxMessages;
-        if (_options.QueueBufferingMaxKbytes.HasValue) producerConfig.QueueBufferingMaxKbytes = _options.QueueBufferingMaxKbytes;
-        if (_options.LingerMs.HasValue) producerConfig.LingerMs = _options.LingerMs;
-        if (_options.MessageSendMaxRetries.HasValue) producerConfig.MessageSendMaxRetries = _options.MessageSendMaxRetries;
-        if (_options.RetryBackoffMs.HasValue) producerConfig.RetryBackoffMs = _options.RetryBackoffMs;
-        if (_options.QueueBufferingBackpressureThreshold.HasValue) producerConfig.QueueBufferingBackpressureThreshold = _options.QueueBufferingBackpressureThreshold;
-        if (_options.CompressionType.HasValue) producerConfig.CompressionType = _options.CompressionType;
         if (_options.BatchNumMessages.HasValue) producerConfig.BatchNumMessages = _options.BatchNumMessages;
         if (_options.BatchSize.HasValue) producerConfig.BatchSize = _options.BatchSize;
+        if (_options.CompressionLevel.HasValue) producerConfig.CompressionLevel = _options.CompressionLevel;
+        if (_options.CompressionType.HasValue) producerConfig.CompressionType = _options.CompressionType;
+        if (!String.IsNullOrEmpty(_options.DeliveryReportFields)) producerConfig.DeliveryReportFields = _options.DeliveryReportFields; // TODO: Producer config throws exception with this property
+        if (_options.EnableBackgroundPoll.HasValue) producerConfig.EnableBackgroundPoll = _options.EnableBackgroundPoll;
+        if (_options.EnableDeliveryReports.HasValue) producerConfig.EnableDeliveryReports = _options.EnableDeliveryReports;
+        if (_options.EnableGaplessGuarantee.HasValue) producerConfig.EnableGaplessGuarantee = _options.EnableGaplessGuarantee;
+        if (_options.EnableIdempotence.HasValue) producerConfig.EnableIdempotence = _options.EnableIdempotence;
+        if (_options.LingerMs.HasValue) producerConfig.LingerMs = _options.LingerMs;
+        if (_options.MessageSendMaxRetries.HasValue) producerConfig.MessageSendMaxRetries = _options.MessageSendMaxRetries;
+        if (_options.MessageTimeoutMs.HasValue) producerConfig.MessageTimeoutMs = _options.MessageTimeoutMs;
+        if (_options.Partitioner.HasValue) producerConfig.Partitioner = _options.Partitioner;
+        if (_options.QueueBufferingBackpressureThreshold.HasValue) producerConfig.QueueBufferingBackpressureThreshold = _options.QueueBufferingBackpressureThreshold;
+        if (_options.QueueBufferingMaxKbytes.HasValue) producerConfig.QueueBufferingMaxKbytes = _options.QueueBufferingMaxKbytes;
+        if (_options.QueueBufferingMaxMessages.HasValue) producerConfig.QueueBufferingMaxMessages = _options.QueueBufferingMaxMessages;
+        if (_options.RequestTimeoutMs.HasValue) producerConfig.RequestTimeoutMs = _options.RequestTimeoutMs;
+        if (_options.RetryBackoffMs.HasValue) producerConfig.RetryBackoffMs = _options.RetryBackoffMs;
         if (_options.StickyPartitioningLingerMs.HasValue) producerConfig.StickyPartitioningLingerMs = _options.StickyPartitioningLingerMs;
+        if (!String.IsNullOrEmpty(_options.TransactionalId)) producerConfig.TransactionalId = _options.TransactionalId;
+        if (_options.TransactionTimeoutMs.HasValue) producerConfig.TransactionTimeoutMs = _options.TransactionTimeoutMs;
 
         return producerConfig;
     }
@@ -602,31 +633,33 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
     {
         var clientConfig = CreateClientConfig();
         var consumerConfig = new ConsumerConfig(clientConfig);
-
-        if (!String.IsNullOrEmpty(_options.GroupId)) consumerConfig.GroupId = _options.GroupId;
-        if (!String.IsNullOrEmpty(_options.GroupInstanceId)) consumerConfig.GroupInstanceId = _options.GroupInstanceId;
-        if (!String.IsNullOrEmpty(_options.ConsumeResultFields)) consumerConfig.ConsumeResultFields = _options.ConsumeResultFields;
-        if (!String.IsNullOrEmpty(_options.GroupProtocolType)) consumerConfig.GroupProtocolType = _options.GroupProtocolType;
-        if (_options.AutoOffsetReset.HasValue) consumerConfig.AutoOffsetReset = _options.AutoOffsetReset;
-        if (_options.PartitionAssignmentStrategy.HasValue) consumerConfig.PartitionAssignmentStrategy = _options.PartitionAssignmentStrategy;
-        if (_options.SessionTimeoutMs.HasValue) consumerConfig.SessionTimeoutMs = _options.SessionTimeoutMs;
-        if (_options.HeartbeatIntervalMs.HasValue) consumerConfig.HeartbeatIntervalMs = _options.HeartbeatIntervalMs;
-        if (_options.CoordinatorQueryIntervalMs.HasValue) consumerConfig.CoordinatorQueryIntervalMs = _options.CoordinatorQueryIntervalMs;
-        if (_options.MaxPollIntervalMs.HasValue) consumerConfig.MaxPollIntervalMs = _options.MaxPollIntervalMs;
-        if (_options.EnableAutoCommit.HasValue) consumerConfig.EnableAutoCommit = _options.EnableAutoCommit;
+        if (_options.AllowAutoCreateTopics.HasValue) consumerConfig.AllowAutoCreateTopics = _options.AllowAutoCreateTopics;
         if (_options.AutoCommitIntervalMs.HasValue) consumerConfig.AutoCommitIntervalMs = _options.AutoCommitIntervalMs;
+        if (_options.AutoOffsetReset.HasValue) consumerConfig.AutoOffsetReset = _options.AutoOffsetReset;
+        if (_options.CheckCrcs.HasValue) consumerConfig.CheckCrcs = _options.CheckCrcs;
+        if (!String.IsNullOrEmpty(_options.ConsumeResultFields)) consumerConfig.ConsumeResultFields = _options.ConsumeResultFields;
+        if (_options.CoordinatorQueryIntervalMs.HasValue) consumerConfig.CoordinatorQueryIntervalMs = _options.CoordinatorQueryIntervalMs;
+        if (_options.EnableAutoCommit.HasValue) consumerConfig.EnableAutoCommit = _options.EnableAutoCommit;
         if (_options.EnableAutoOffsetStore.HasValue) consumerConfig.EnableAutoOffsetStore = _options.EnableAutoOffsetStore;
-        if (_options.QueuedMinMessages.HasValue) consumerConfig.QueuedMinMessages = _options.QueuedMinMessages;
-        if (_options.QueuedMaxMessagesKbytes.HasValue) consumerConfig.QueuedMaxMessagesKbytes = _options.QueuedMaxMessagesKbytes;
-        if (_options.FetchWaitMaxMs.HasValue) consumerConfig.FetchWaitMaxMs = _options.FetchWaitMaxMs;
-        if (_options.MaxPartitionFetchBytes.HasValue) consumerConfig.MaxPartitionFetchBytes = _options.MaxPartitionFetchBytes;
+        if (_options.EnablePartitionEof.HasValue) consumerConfig.EnablePartitionEof = _options.EnablePartitionEof;
+        if (_options.FetchErrorBackoffMs.HasValue) consumerConfig.FetchErrorBackoffMs = _options.FetchErrorBackoffMs;
         if (_options.FetchMaxBytes.HasValue) consumerConfig.FetchMaxBytes = _options.FetchMaxBytes;
         if (_options.FetchMinBytes.HasValue) consumerConfig.FetchMinBytes = _options.FetchMinBytes;
-        if (_options.FetchErrorBackoffMs.HasValue) consumerConfig.FetchErrorBackoffMs = _options.FetchErrorBackoffMs;
+        if (_options.FetchQueueBackoffMs.HasValue) consumerConfig.FetchQueueBackoffMs = _options.FetchQueueBackoffMs;
+        if (_options.FetchWaitMaxMs.HasValue) consumerConfig.FetchWaitMaxMs = _options.FetchWaitMaxMs;
+        if (!String.IsNullOrEmpty(_options.GroupId)) consumerConfig.GroupId = _options.GroupId;
+        if (!String.IsNullOrEmpty(_options.GroupInstanceId)) consumerConfig.GroupInstanceId = _options.GroupInstanceId;
+        if (_options.GroupProtocol.HasValue) consumerConfig.GroupProtocol = _options.GroupProtocol;
+        if (!String.IsNullOrEmpty(_options.GroupProtocolType)) consumerConfig.GroupProtocolType = _options.GroupProtocolType;
+        if (!String.IsNullOrEmpty(_options.GroupRemoteAssignor)) consumerConfig.GroupRemoteAssignor = _options.GroupRemoteAssignor;
+        if (_options.HeartbeatIntervalMs.HasValue) consumerConfig.HeartbeatIntervalMs = _options.HeartbeatIntervalMs;
         if (_options.IsolationLevel.HasValue) consumerConfig.IsolationLevel = _options.IsolationLevel;
-        if (_options.EnablePartitionEof.HasValue) consumerConfig.EnablePartitionEof = _options.EnablePartitionEof;
-        if (_options.CheckCrcs.HasValue) consumerConfig.CheckCrcs = _options.CheckCrcs;
-        if (_options.AllowAutoCreateTopics.HasValue) consumerConfig.AllowAutoCreateTopics = _options.AllowAutoCreateTopics;
+        if (_options.MaxPartitionFetchBytes.HasValue) consumerConfig.MaxPartitionFetchBytes = _options.MaxPartitionFetchBytes;
+        if (_options.MaxPollIntervalMs.HasValue) consumerConfig.MaxPollIntervalMs = _options.MaxPollIntervalMs;
+        if (_options.PartitionAssignmentStrategy.HasValue) consumerConfig.PartitionAssignmentStrategy = _options.PartitionAssignmentStrategy;
+        if (_options.QueuedMaxMessagesKbytes.HasValue) consumerConfig.QueuedMaxMessagesKbytes = _options.QueuedMaxMessagesKbytes;
+        if (_options.QueuedMinMessages.HasValue) consumerConfig.QueuedMinMessages = _options.QueuedMinMessages;
+        if (_options.SessionTimeoutMs.HasValue) consumerConfig.SessionTimeoutMs = _options.SessionTimeoutMs;
 
         return consumerConfig;
     }

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBusOptions.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBusOptions.cs
@@ -645,7 +645,7 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public AutoOffsetReset? AutoOffsetReset { get; set; } = Confluent.Kafka.AutoOffsetReset.Earliest;
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.EnablePartitionEof"/>
+    /// <inheritdoc cref="ConsumerConfig.CheckCrcs"/>
     /// </summary>
     public bool? CheckCrcs { get; set; }
 

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBusOptions.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBusOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
@@ -17,52 +17,12 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     /// </summary>
     public string? GroupId { get; set; }
 
-    /// <summary>
-    /// Resolve a message type from a custom source.
-    /// </summary>
-    public Func<ConsumeResult<string, byte[]>, string?>? ResolveMessageType { get; set; }
-
     public string ContentType { get; set; } = "application/json";
 
     /// <summary>
     /// <inheritdoc cref="Message{TKey,TValue}.Key"/>
     /// </summary>
     public string? PublishKey { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.AutoCommitIntervalMs"/>
-    /// </summary>
-    public int? AutoCommitIntervalMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslCertificateLocation"/>
-    /// </summary>
-    public string? SslCertificateLocation { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslMechanism"/>
-    /// </summary>
-    public SaslMechanism? SaslMechanism { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslUsername"/>
-    /// </summary>
-    public string? SaslUsername { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslPassword"/>
-    /// </summary>
-    public string? SaslPassword { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslCaLocation"/>
-    /// </summary>
-    public string? SslCaLocation { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SecurityProtocol"/>
-    /// </summary>
-    public SecurityProtocol? SecurityProtocol { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="TopicSpecification.NumPartitions"/>
@@ -85,154 +45,24 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public Dictionary<int, List<int>>? TopicReplicasAssignments { get; set; }
 
     /// <summary>
+    /// Resolve a message type from a custom source.
+    /// </summary>
+    public Func<ConsumeResult<string, byte[]>, string?>? ResolveMessageType { get; set; }
+
+    /// <summary>
     /// <inheritdoc cref="ClientConfig.Acks"/>
     /// </summary>
     public Acks? Acks { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.ClientId"/>
+    /// <inheritdoc cref="ClientConfig.AllowAutoCreateTopics"/>
     /// </summary>
-    public string? ClientId { get; set; }
+    public bool? AllowAutoCreateTopics { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.MessageMaxBytes"/>
+    /// <inheritdoc cref="ClientConfig.ApiVersionFallbackMs"/>
     /// </summary>
-    public int? MessageMaxBytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.MessageCopyMaxBytes"/>
-    /// </summary>
-    public int? MessageCopyMaxBytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.ReceiveMessageMaxBytes"/>
-    /// </summary>
-    public int? ReceiveMessageMaxBytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.MaxInFlight"/>
-    /// </summary>
-    public int? MaxInFlight { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.TopicMetadataRefreshIntervalMs"/>
-    /// </summary>
-    public int? TopicMetadataRefreshIntervalMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.MetadataMaxAgeMs"/>
-    /// </summary>
-    public int? MetadataMaxAgeMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.TopicMetadataRefreshFastIntervalMs"/>
-    /// </summary>
-    public int? TopicMetadataRefreshFastIntervalMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.TopicMetadataRefreshSparse"/>
-    /// </summary>
-    public bool? TopicMetadataRefreshSparse { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.TopicMetadataPropagationMaxMs"/>
-    /// </summary>
-    public int? TopicMetadataPropagationMaxMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.TopicBlacklist"/>
-    /// </summary>
-    public string? TopicBlacklist { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.Debug"/>
-    /// </summary>
-    public string? Debug { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SocketTimeoutMs"/>
-    /// </summary>
-    public int? SocketTimeoutMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SocketSendBufferBytes"/>
-    /// </summary>
-    public int? SocketSendBufferBytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SocketReceiveBufferBytes"/>
-    /// </summary>
-    public int? SocketReceiveBufferBytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SocketKeepaliveEnable"/>
-    /// </summary>
-    public bool? SocketKeepaliveEnable { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SocketNagleDisable"/>
-    /// </summary>
-    public bool? SocketNagleDisable { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SocketMaxFails"/>
-    /// </summary>
-    public int? SocketMaxFails { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.BrokerAddressTtl"/>
-    /// </summary>
-    public int? BrokerAddressTtl { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.BrokerAddressFamily"/>
-    /// </summary>
-    public BrokerAddressFamily? BrokerAddressFamily { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.ConnectionsMaxIdleMs"/>
-    /// </summary>
-    public int? ConnectionsMaxIdleMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.ReconnectBackoffMs"/>
-    /// </summary>
-    public int? ReconnectBackoffMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.ReconnectBackoffMaxMs"/>
-    /// </summary>
-    public int? ReconnectBackoffMaxMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.StatisticsIntervalMs"/>
-    /// </summary>
-    public int? StatisticsIntervalMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.LogQueue"/>
-    /// </summary>
-    public bool? LogQueue { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.LogThreadName"/>
-    /// </summary>
-    public bool? LogThreadName { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.EnableRandomSeed"/>
-    /// </summary>
-    public bool? EnableRandomSeed { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.LogConnectionClose"/>
-    /// </summary>
-    public bool? LogConnectionClose { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.InternalTerminationSignal"/>
-    /// </summary>
-    public int? InternalTerminationSignal { get; set; }
+    public int? ApiVersionFallbackMs { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ClientConfig.ApiVersionRequest"/>
@@ -245,9 +75,14 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public int? ApiVersionRequestTimeoutMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.ApiVersionFallbackMs"/>
+    /// <inheritdoc cref="ClientConfig.BrokerAddressFamily"/>
     /// </summary>
-    public int? ApiVersionFallbackMs { get; set; }
+    public BrokerAddressFamily? BrokerAddressFamily { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.BrokerAddressTtl"/>
+    /// </summary>
+    public int? BrokerAddressTtl { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ClientConfig.BrokerVersionFallback"/>
@@ -255,9 +90,364 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public string? BrokerVersionFallback { get; set; }
 
     /// <summary>
+    /// <inheritdoc cref="ClientConfig.ClientDnsLookup"/>
+    /// </summary>
+    public ClientDnsLookup? ClientDnsLookup { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.ClientId"/>
+    /// </summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.ClientRack"/>
+    /// </summary>
+    public string? ClientRack { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.ConnectionsMaxIdleMs"/>
+    /// </summary>
+    public int? ConnectionsMaxIdleMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.Debug"/>
+    /// </summary>
+    public string? Debug { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.EnableMetricsPush"/>
+    /// </summary>
+    public bool? EnableMetricsPush { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.EnableRandomSeed"/>
+    /// </summary>
+    public bool? EnableRandomSeed { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.EnableSaslOauthbearerUnsecureJwt"/>
+    /// </summary>
+    public bool? EnableSaslOauthbearerUnsecureJwt { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.EnableSslCertificateVerification"/>
+    /// </summary>
+    public bool? EnableSslCertificateVerification { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.HttpsCaLocation"/>
+    /// </summary>
+    public string? HttpsCaLocation { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.HttpsCaPem"/>
+    /// </summary>
+    public string? HttpsCaPem { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.InternalTerminationSignal"/>
+    /// </summary>
+    public int? InternalTerminationSignal { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.LogConnectionClose"/>
+    /// </summary>
+    public bool? LogConnectionClose { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.LogQueue"/>
+    /// </summary>
+    public bool? LogQueue { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.LogThreadName"/>
+    /// </summary>
+    public bool? LogThreadName { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.MaxInFlight"/>
+    /// </summary>
+    public int? MaxInFlight { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.MessageCopyMaxBytes"/>
+    /// </summary>
+    public int? MessageCopyMaxBytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.MessageMaxBytes"/>
+    /// </summary>
+    public int? MessageMaxBytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.MetadataMaxAgeMs"/>
+    /// </summary>
+    public int? MetadataMaxAgeMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.MetadataRecoveryRebootstrapTriggerMs"/>
+    /// </summary>
+    public int? MetadataRecoveryRebootstrapTriggerMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.MetadataRecoveryStrategy"/>
+    /// </summary>
+    public MetadataRecoveryStrategy? MetadataRecoveryStrategy { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.PluginLibraryPaths"/>
+    /// </summary>
+    public string? PluginLibraryPaths { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.ReceiveMessageMaxBytes"/>
+    /// </summary>
+    public int? ReceiveMessageMaxBytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.ReconnectBackoffMaxMs"/>
+    /// </summary>
+    public int? ReconnectBackoffMaxMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.ReconnectBackoffMs"/>
+    /// </summary>
+    public int? ReconnectBackoffMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.RetryBackoffMaxMs"/>
+    /// </summary>
+    public int? RetryBackoffMaxMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.RetryBackoffMs"/>
+    /// </summary>
+    public int? RetryBackoffMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslKerberosKeytab"/>
+    /// </summary>
+    public string? SaslKerberosKeytab { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslKerberosKinitCmd"/>
+    /// </summary>
+    public string? SaslKerberosKinitCmd { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslKerberosMinTimeBeforeRelogin"/>
+    /// </summary>
+    public int? SaslKerberosMinTimeBeforeRelogin { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslKerberosPrincipal"/>
+    /// </summary>
+    public string? SaslKerberosPrincipal { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslKerberosServiceName"/>
+    /// </summary>
+    public string? SaslKerberosServiceName { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslMechanism"/>
+    /// </summary>
+    public SaslMechanism? SaslMechanism { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionAlgorithm"/>
+    /// </summary>
+    public SaslOauthbearerAssertionAlgorithm? SaslOauthbearerAssertionAlgorithm { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionClaimAud"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionClaimAud { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionClaimExpSeconds"/>
+    /// </summary>
+    public int? SaslOauthbearerAssertionClaimExpSeconds { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionClaimIss"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionClaimIss { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionClaimJtiInclude"/>
+    /// </summary>
+    public bool? SaslOauthbearerAssertionClaimJtiInclude { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionClaimNbfSeconds"/>
+    /// </summary>
+    public int? SaslOauthbearerAssertionClaimNbfSeconds { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionClaimSub"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionClaimSub { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionFile"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionFile { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionJwtTemplateFile"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionJwtTemplateFile { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionPrivateKeyFile"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionPrivateKeyFile { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionPrivateKeyPassphrase"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionPrivateKeyPassphrase { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerAssertionPrivateKeyPem"/>
+    /// </summary>
+    public string? SaslOauthbearerAssertionPrivateKeyPem { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerClientId"/>
+    /// </summary>
+    public string? SaslOauthbearerClientId { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerClientSecret"/>
+    /// </summary>
+    public string? SaslOauthbearerClientSecret { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerConfig"/>
+    /// </summary>
+    public string? SaslOauthbearerConfig { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerExtensions"/>
+    /// </summary>
+    public string? SaslOauthbearerExtensions { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerGrantType"/>
+    /// </summary>
+    public SaslOauthbearerGrantType? SaslOauthbearerGrantType { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerMetadataAuthenticationType"/>
+    /// </summary>
+    public SaslOauthbearerMetadataAuthenticationType? SaslOauthbearerMetadataAuthenticationType { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerMethod"/>
+    /// </summary>
+    public SaslOauthbearerMethod? SaslOauthbearerMethod { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerScope"/>
+    /// </summary>
+    public string? SaslOauthbearerScope { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerSubClaimName"/>
+    /// </summary>
+    public string? SaslOauthbearerSubClaimName { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslOauthbearerTokenEndpointUrl"/>
+    /// </summary>
+    public string? SaslOauthbearerTokenEndpointUrl { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslPassword"/>
+    /// </summary>
+    public string? SaslPassword { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SaslUsername"/>
+    /// </summary>
+    public string? SaslUsername { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SecurityProtocol"/>
+    /// </summary>
+    public SecurityProtocol? SecurityProtocol { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketConnectionSetupTimeoutMs"/>
+    /// </summary>
+    public int? SocketConnectionSetupTimeoutMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketKeepaliveEnable"/>
+    /// </summary>
+    public bool? SocketKeepaliveEnable { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketMaxFails"/>
+    /// </summary>
+    public int? SocketMaxFails { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketNagleDisable"/>
+    /// </summary>
+    public bool? SocketNagleDisable { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketReceiveBufferBytes"/>
+    /// </summary>
+    public int? SocketReceiveBufferBytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketSendBufferBytes"/>
+    /// </summary>
+    public int? SocketSendBufferBytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SocketTimeoutMs"/>
+    /// </summary>
+    public int? SocketTimeoutMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslCaCertificateStores"/>
+    /// </summary>
+    public string? SslCaCertificateStores { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslCaLocation"/>
+    /// </summary>
+    public string? SslCaLocation { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslCaPem"/>
+    /// </summary>
+    public string? SslCaPem { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslCertificateLocation"/>
+    /// </summary>
+    public string? SslCertificateLocation { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslCertificatePem"/>
+    /// </summary>
+    public string? SslCertificatePem { get; set; }
+
+    /// <summary>
     /// <inheritdoc cref="ClientConfig.SslCipherSuites"/>
     /// </summary>
     public string? SslCipherSuites { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslCrlLocation"/>
+    /// </summary>
+    public string? SslCrlLocation { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ClientConfig.SslCurvesList"/>
@@ -265,9 +455,19 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public string? SslCurvesList { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslSigalgsList"/>
+    /// <inheritdoc cref="ClientConfig.SslEndpointIdentificationAlgorithm"/>
     /// </summary>
-    public string? SslSigalgsList { get; set; }
+    public SslEndpointIdentificationAlgorithm? SslEndpointIdentificationAlgorithm { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslEngineId"/>
+    /// </summary>
+    public string? SslEngineId { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ClientConfig.SslEngineLocation"/>
+    /// </summary>
+    public string? SslEngineLocation { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ClientConfig.SslKeyLocation"/>
@@ -285,26 +485,6 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public string? SslKeyPem { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslCertificatePem"/>
-    /// </summary>
-    public string? SslCertificatePem { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslCaPem"/>
-    /// </summary>
-    public string? SslCaPem { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslCaCertificateStores"/>
-    /// </summary>
-    public string? SslCaCertificateStores { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslCrlLocation"/>
-    /// </summary>
-    public string? SslCrlLocation { get; set; }
-
-    /// <summary>
     /// <inheritdoc cref="ClientConfig.SslKeystoreLocation"/>
     /// </summary>
     public string? SslKeystoreLocation { get; set; }
@@ -315,159 +495,44 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public string? SslKeystorePassword { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslEngineLocation"/>
+    /// <inheritdoc cref="ClientConfig.SslProviders"/>
     /// </summary>
-    public string? SslEngineLocation { get; set; }
+    public string? SslProviders { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslEngineId"/>
+    /// <inheritdoc cref="ClientConfig.SslSigalgsList"/>
     /// </summary>
-    public string? SslEngineId { get; set; }
+    public string? SslSigalgsList { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.EnableSslCertificateVerification"/>
+    /// <inheritdoc cref="ClientConfig.StatisticsIntervalMs"/>
     /// </summary>
-    public bool? EnableSslCertificateVerification { get; set; }
+    public int? StatisticsIntervalMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SslEndpointIdentificationAlgorithm"/>
+    /// <inheritdoc cref="ClientConfig.TopicBlacklist"/>
     /// </summary>
-    public SslEndpointIdentificationAlgorithm? SslEndpointIdentificationAlgorithm { get; set; }
+    public string? TopicBlacklist { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslKerberosServiceName"/>
+    /// <inheritdoc cref="ClientConfig.TopicMetadataPropagationMaxMs"/>
     /// </summary>
-    public string? SaslKerberosServiceName { get; set; }
+    public int? TopicMetadataPropagationMaxMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslKerberosPrincipal"/>
+    /// <inheritdoc cref="ClientConfig.TopicMetadataRefreshFastIntervalMs"/>
     /// </summary>
-    public string? SaslKerberosPrincipal { get; set; }
+    public int? TopicMetadataRefreshFastIntervalMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslKerberosKinitCmd"/>
+    /// <inheritdoc cref="ClientConfig.TopicMetadataRefreshIntervalMs"/>
     /// </summary>
-    public string? SaslKerberosKinitCmd { get; set; }
+    public int? TopicMetadataRefreshIntervalMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslKerberosKeytab"/>
+    /// <inheritdoc cref="ClientConfig.TopicMetadataRefreshSparse"/>
     /// </summary>
-    public string? SaslKerberosKeytab { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslKerberosMinTimeBeforeRelogin"/>
-    /// </summary>
-    public int? SaslKerberosMinTimeBeforeRelogin { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.SaslOauthbearerConfig"/>
-    /// </summary>
-    public string? SaslOauthbearerConfig { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.EnableSaslOauthbearerUnsecureJwt"/>
-    /// </summary>
-    public bool? EnableSaslOauthbearerUnsecureJwt { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.PluginLibraryPaths"/>
-    /// </summary>
-    public string? PluginLibraryPaths { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.ClientRack"/>
-    /// </summary>
-    public string? ClientRack { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.EnableBackgroundPoll"/>
-    /// </summary>
-    public bool? EnableBackgroundPoll { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.EnableDeliveryReports"/>
-    /// </summary>
-    public bool? EnableDeliveryReports { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.DeliveryReportFields"/>
-    /// </summary>
-    public string? DeliveryReportFields { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.RequestTimeoutMs"/>
-    /// </summary>
-    public int? RequestTimeoutMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.MessageTimeoutMs"/>
-    /// </summary>
-    public int? MessageTimeoutMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.Partitioner"/>
-    /// </summary>
-    public Partitioner? Partitioner { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.CompressionLevel"/>
-    /// </summary>
-    public int? CompressionLevel { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.TransactionalId"/>
-    /// </summary>
-    public string? TransactionalId { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.TransactionTimeoutMs"/>
-    /// </summary>
-    public int? TransactionTimeoutMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.EnableIdempotence"/>
-    /// </summary>
-    public bool? EnableIdempotence { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.EnableGaplessGuarantee"/>
-    /// </summary>
-    public bool? EnableGaplessGuarantee { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.QueueBufferingMaxMessages"/>
-    /// </summary>
-    public int? QueueBufferingMaxMessages { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.QueueBufferingMaxKbytes"/>
-    /// </summary>
-    public int? QueueBufferingMaxKbytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.LingerMs"/>
-    /// </summary>
-    public double? LingerMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.MessageSendMaxRetries"/>
-    /// </summary>
-    public int? MessageSendMaxRetries { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ClientConfig.RetryBackoffMs"/>
-    /// </summary>
-    public int? RetryBackoffMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.QueueBufferingBackpressureThreshold"/>
-    /// </summary>
-    public int? QueueBufferingBackpressureThreshold { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ProducerConfig.CompressionType"/>
-    /// </summary>
-    public CompressionType? CompressionType { get; set; }
+    public bool? TopicMetadataRefreshSparse { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ProducerConfig.BatchNumMessages"/>
@@ -480,14 +545,99 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public int? BatchSize { get; set; }
 
     /// <summary>
+    /// <inheritdoc cref="ProducerConfig.CompressionLevel"/>
+    /// </summary>
+    public int? CompressionLevel { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.CompressionType"/>
+    /// </summary>
+    public CompressionType? CompressionType { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.DeliveryReportFields"/>
+    /// </summary>
+    public string? DeliveryReportFields { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.EnableBackgroundPoll"/>
+    /// </summary>
+    public bool? EnableBackgroundPoll { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.EnableDeliveryReports"/>
+    /// </summary>
+    public bool? EnableDeliveryReports { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.EnableGaplessGuarantee"/>
+    /// </summary>
+    public bool? EnableGaplessGuarantee { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.EnableIdempotence"/>
+    /// </summary>
+    public bool? EnableIdempotence { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.LingerMs"/>
+    /// </summary>
+    public double? LingerMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.MessageSendMaxRetries"/>
+    /// </summary>
+    public int? MessageSendMaxRetries { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.MessageTimeoutMs"/>
+    /// </summary>
+    public int? MessageTimeoutMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.Partitioner"/>
+    /// </summary>
+    public Partitioner? Partitioner { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.QueueBufferingBackpressureThreshold"/>
+    /// </summary>
+    public int? QueueBufferingBackpressureThreshold { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.QueueBufferingMaxKbytes"/>
+    /// </summary>
+    public int? QueueBufferingMaxKbytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.QueueBufferingMaxMessages"/>
+    /// </summary>
+    public int? QueueBufferingMaxMessages { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.RequestTimeoutMs"/>
+    /// </summary>
+    public int? RequestTimeoutMs { get; set; }
+
+    /// <summary>
     /// <inheritdoc cref="ProducerConfig.StickyPartitioningLingerMs"/>
     /// </summary>
     public int? StickyPartitioningLingerMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.ConsumeResultFields"/>
+    /// <inheritdoc cref="ProducerConfig.TransactionTimeoutMs"/>
     /// </summary>
-    public string? ConsumeResultFields { get; set; }
+    public int? TransactionTimeoutMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ProducerConfig.TransactionalId"/>
+    /// </summary>
+    public string? TransactionalId { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.AutoCommitIntervalMs"/>
+    /// </summary>
+    public int? AutoCommitIntervalMs { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ConsumerConfig.AutoOffsetReset"/>
@@ -495,39 +645,19 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public AutoOffsetReset? AutoOffsetReset { get; set; } = Confluent.Kafka.AutoOffsetReset.Earliest;
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.GroupInstanceId"/>
+    /// <inheritdoc cref="ConsumerConfig.EnablePartitionEof"/>
     /// </summary>
-    public string? GroupInstanceId { get; set; }
+    public bool? CheckCrcs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.PartitionAssignmentStrategy"/>
+    /// <inheritdoc cref="ConsumerConfig.ConsumeResultFields"/>
     /// </summary>
-    public PartitionAssignmentStrategy? PartitionAssignmentStrategy { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.SessionTimeoutMs"/>
-    /// </summary>
-    public int? SessionTimeoutMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.HeartbeatIntervalMs"/>
-    /// </summary>
-    public int? HeartbeatIntervalMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.GroupProtocolType"/>
-    /// </summary>
-    public string? GroupProtocolType { get; set; }
+    public string? ConsumeResultFields { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ConsumerConfig.CoordinatorQueryIntervalMs"/>
     /// </summary>
     public int? CoordinatorQueryIntervalMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.MaxPollIntervalMs"/>
-    /// </summary>
-    public int? MaxPollIntervalMs { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ConsumerConfig.EnableAutoCommit"/>
@@ -540,24 +670,14 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public bool? EnableAutoOffsetStore { get; set; } = false;
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.QueuedMinMessages"/>
+    /// <inheritdoc cref="ConsumerConfig.EnablePartitionEof"/>
     /// </summary>
-    public int? QueuedMinMessages { get; set; }
+    public bool? EnablePartitionEof { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.QueuedMaxMessagesKbytes"/>
+    /// <inheritdoc cref="ConsumerConfig.FetchErrorBackoffMs"/>
     /// </summary>
-    public int? QueuedMaxMessagesKbytes { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.FetchWaitMaxMs"/>
-    /// </summary>
-    public int? FetchWaitMaxMs { get; set; }
-
-    /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.MaxPartitionFetchBytes"/>
-    /// </summary>
-    public int? MaxPartitionFetchBytes { get; set; }
+    public int? FetchErrorBackoffMs { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ConsumerConfig.FetchMaxBytes"/>
@@ -570,9 +690,39 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public int? FetchMinBytes { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.FetchErrorBackoffMs"/>
+    /// <inheritdoc cref="ConsumerConfig.FetchQueueBackoffMs"/>
     /// </summary>
-    public int? FetchErrorBackoffMs { get; set; }
+    public int? FetchQueueBackoffMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.FetchWaitMaxMs"/>
+    /// </summary>
+    public int? FetchWaitMaxMs { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.GroupInstanceId"/>
+    /// </summary>
+    public string? GroupInstanceId { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.GroupProtocol"/>
+    /// </summary>
+    public GroupProtocol? GroupProtocol { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.GroupProtocolType"/>
+    /// </summary>
+    public string? GroupProtocolType { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.GroupRemoteAssignor"/>
+    /// </summary>
+    public string? GroupRemoteAssignor { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.HeartbeatIntervalMs"/>
+    /// </summary>
+    public int? HeartbeatIntervalMs { get; set; }
 
     /// <summary>
     /// <inheritdoc cref="ConsumerConfig.IsolationLevel"/>
@@ -580,19 +730,34 @@ public class KafkaMessageBusOptions : SharedMessageBusOptions
     public IsolationLevel? IsolationLevel { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.EnablePartitionEof"/>
+    /// <inheritdoc cref="ConsumerConfig.MaxPartitionFetchBytes"/>
     /// </summary>
-    public bool? EnablePartitionEof { get; set; }
+    public int? MaxPartitionFetchBytes { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ConsumerConfig.EnablePartitionEof"/>
+    /// <inheritdoc cref="ConsumerConfig.MaxPollIntervalMs"/>
     /// </summary>
-    public bool? CheckCrcs { get; set; }
+    public int? MaxPollIntervalMs { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ClientConfig.AllowAutoCreateTopics"/>
+    /// <inheritdoc cref="ConsumerConfig.PartitionAssignmentStrategy"/>
     /// </summary>
-    public bool? AllowAutoCreateTopics { get; set; }
+    public PartitionAssignmentStrategy? PartitionAssignmentStrategy { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.QueuedMaxMessagesKbytes"/>
+    /// </summary>
+    public int? QueuedMaxMessagesKbytes { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.QueuedMinMessages"/>
+    /// </summary>
+    public int? QueuedMinMessages { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="ConsumerConfig.SessionTimeoutMs"/>
+    /// </summary>
+    public int? SessionTimeoutMs { get; set; }
 }
 
 public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<KafkaMessageBusOptions, KafkaMessageBusOptionsBuilder>
@@ -625,83 +790,11 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.AutoCommitIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder AutoCommitIntervalMs(int autoCommitIntervalMs)
-    {
-        Target.AutoCommitIntervalMs = autoCommitIntervalMs;
-        return this;
-    }
-
-    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.PublishKey"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder PublishKey(string publishKey)
     {
         Target.PublishKey = publishKey ?? throw new ArgumentNullException(nameof(publishKey));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslCertificateLocation"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SslCertificateLocation(string sslCertificateLocation)
-    {
-        Target.SslCertificateLocation = sslCertificateLocation ?? throw new ArgumentNullException(nameof(sslCertificateLocation));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslMechanism"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslMechanism(SaslMechanism? saslMechanism)
-    {
-        Target.SaslMechanism = saslMechanism ?? throw new ArgumentNullException(nameof(saslMechanism));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslUsername"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslUsername(string saslUsername)
-    {
-        Target.SaslUsername = saslUsername ?? throw new ArgumentNullException(nameof(saslUsername));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslPassword"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslPassword(string saslPassword)
-    {
-        Target.SaslPassword = saslPassword ?? throw new ArgumentNullException(nameof(saslPassword));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslCaLocation"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SslCaLocation(string sslCaLocation)
-    {
-        Target.SslCaLocation = sslCaLocation ?? throw new ArgumentNullException(nameof(sslCaLocation));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SecurityProtocol"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SecurityProtocol(SecurityProtocol? securityProtocol)
-    {
-        Target.SecurityProtocol = securityProtocol ?? throw new ArgumentNullException(nameof(securityProtocol));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.AutoCommitIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder AutoCommitIntervalMs(int? autoCommitIntervalMs)
-    {
-        Target.AutoCommitIntervalMs = autoCommitIntervalMs ?? throw new ArgumentNullException(nameof(autoCommitIntervalMs));
         return this;
     }
 
@@ -724,60 +817,6 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.Acks"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder Acks(Acks? acks)
-    {
-        Target.Acks = acks ?? throw new ArgumentNullException(nameof(acks));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ClientId"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder ClientId(string clientId)
-    {
-        Target.ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MessageMaxBytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MessageMaxBytes(int? messageMaxBytes)
-    {
-        Target.MessageMaxBytes = messageMaxBytes ?? throw new ArgumentNullException(nameof(messageMaxBytes));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MessageCopyMaxBytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MessageCopyMaxBytes(int? messageCopyMaxBytes)
-    {
-        Target.MessageCopyMaxBytes = messageCopyMaxBytes ?? throw new ArgumentNullException(nameof(messageCopyMaxBytes));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ReceiveMessageMaxBytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder ReceiveMessageMaxBytes(int? receiveMessageMaxBytes)
-    {
-        Target.ReceiveMessageMaxBytes = receiveMessageMaxBytes ?? throw new ArgumentNullException(nameof(receiveMessageMaxBytes));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MaxInFlight"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MaxInFlight(int? maxInFlight)
-    {
-        Target.MaxInFlight = maxInFlight ?? throw new ArgumentNullException(nameof(maxInFlight));
-        return this;
-    }
-
-    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.TopicConfigs"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder TopicConfigs(Dictionary<string, string> topicConfigs)
@@ -796,123 +835,6 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataRefreshIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TopicMetadataRefreshIntervalMs(int? topicMetadataRefreshIntervalMs)
-    {
-        Target.TopicMetadataRefreshIntervalMs = topicMetadataRefreshIntervalMs ?? throw new ArgumentNullException(nameof(topicMetadataRefreshIntervalMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MetadataMaxAgeMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MetadataMaxAgeMs(int? metadataMaxAgeMs)
-    {
-        Target.MetadataMaxAgeMs = metadataMaxAgeMs ?? throw new ArgumentNullException(nameof(metadataMaxAgeMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataRefreshFastIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TopicMetadataRefreshFastIntervalMs(int? topicMetadataRefreshFastIntervalMs)
-    {
-        Target.TopicMetadataRefreshFastIntervalMs = topicMetadataRefreshFastIntervalMs ?? throw new ArgumentNullException(nameof(topicMetadataRefreshFastIntervalMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataRefreshSparse"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TopicMetadataRefreshSparse(bool? topicMetadataRefreshSparse)
-    {
-        Target.TopicMetadataRefreshSparse = topicMetadataRefreshSparse ?? throw new ArgumentNullException(nameof(topicMetadataRefreshSparse));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataPropagationMaxMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TopicMetadataPropagationMaxMs(int? topicMetadataPropagationMaxMs)
-    {
-        Target.TopicMetadataPropagationMaxMs = topicMetadataPropagationMaxMs ?? throw new ArgumentNullException(nameof(topicMetadataPropagationMaxMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TopicBlacklist"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TopicBlacklist(string topicBlacklist)
-    {
-        Target.TopicBlacklist = topicBlacklist ?? throw new ArgumentNullException(nameof(topicBlacklist));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.Debug"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder Debug(string debug)
-    {
-        Target.Debug = debug ?? throw new ArgumentNullException(nameof(debug));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SocketTimeoutMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SocketTimeoutMs(int? socketTimeoutMs)
-    {
-        Target.SocketTimeoutMs = socketTimeoutMs ?? throw new ArgumentNullException(nameof(socketTimeoutMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SocketSendBufferBytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SocketSendBufferBytes(int? socketSendBufferBytes)
-    {
-        Target.SocketSendBufferBytes = socketSendBufferBytes ?? throw new ArgumentNullException(nameof(socketSendBufferBytes));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SocketReceiveBufferBytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SocketReceiveBufferBytes(int? socketReceiveBufferBytes)
-    {
-        Target.SocketReceiveBufferBytes = socketReceiveBufferBytes ?? throw new ArgumentNullException(nameof(socketReceiveBufferBytes));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SocketKeepaliveEnable"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SocketKeepaliveEnable(bool? socketKeepaliveEnable)
-    {
-        Target.SocketKeepaliveEnable = socketKeepaliveEnable ?? throw new ArgumentNullException(nameof(socketKeepaliveEnable));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SocketNagleDisable"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SocketNagleDisable(bool? socketNagleDisable)
-    {
-        Target.SocketNagleDisable = socketNagleDisable ?? throw new ArgumentNullException(nameof(socketNagleDisable));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SocketMaxFails"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SocketMaxFails(int? socketMaxFails)
-    {
-        Target.SocketMaxFails = socketMaxFails ?? throw new ArgumentNullException(nameof(socketMaxFails));
-        return this;
-    }
-
-    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.BootstrapServers"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder BrokerAddressTtl(int? brokerAddressTtl)
@@ -922,92 +844,29 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.BrokerAddressFamily"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.Acks"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder BrokerAddressFamily(BrokerAddressFamily? brokerAddressFamily)
+    public KafkaMessageBusOptionsBuilder Acks(Acks? acks)
     {
-        Target.BrokerAddressFamily = brokerAddressFamily ?? throw new ArgumentNullException(nameof(brokerAddressFamily));
+        Target.Acks = acks ?? throw new ArgumentNullException(nameof(acks));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ConnectionsMaxIdleMs"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.AllowAutoCreateTopics"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder ConnectionsMaxIdleMs(int? connectionsMaxIdleMs)
+    public KafkaMessageBusOptionsBuilder AllowAutoCreateTopics(bool? allowAutoCreateTopics)
     {
-        Target.ConnectionsMaxIdleMs = connectionsMaxIdleMs ?? throw new ArgumentNullException(nameof(connectionsMaxIdleMs));
+        Target.AllowAutoCreateTopics = allowAutoCreateTopics ?? throw new ArgumentNullException(nameof(allowAutoCreateTopics));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ReconnectBackoffMs"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ApiVersionFallbackMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder ReconnectBackoffMs(int? reconnectBackoffMs)
+    public KafkaMessageBusOptionsBuilder ApiVersionFallbackMs(int? apiVersionFallbackMs)
     {
-        Target.ReconnectBackoffMs = reconnectBackoffMs ?? throw new ArgumentNullException(nameof(reconnectBackoffMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ReconnectBackoffMaxMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder ReconnectBackoffMaxMs(int? reconnectBackoffMaxMs)
-    {
-        Target.ReconnectBackoffMaxMs = reconnectBackoffMaxMs ?? throw new ArgumentNullException(nameof(reconnectBackoffMaxMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.StatisticsIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder StatisticsIntervalMs(int? statisticsIntervalMs)
-    {
-        Target.StatisticsIntervalMs = statisticsIntervalMs ?? throw new ArgumentNullException(nameof(statisticsIntervalMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.LogQueue"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder LogQueue(bool? logQueue)
-    {
-        Target.LogQueue = logQueue ?? throw new ArgumentNullException(nameof(logQueue));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.LogThreadName"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder LogThreadName(bool? logThreadName)
-    {
-        Target.LogThreadName = logThreadName ?? throw new ArgumentNullException(nameof(logThreadName));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableRandomSeed"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableRandomSeed(bool? enableRandomSeed)
-    {
-        Target.EnableRandomSeed = enableRandomSeed ?? throw new ArgumentNullException(nameof(enableRandomSeed));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.LogConnectionClose"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder LogConnectionClose(bool? logConnectionClose)
-    {
-        Target.LogConnectionClose = logConnectionClose ?? throw new ArgumentNullException(nameof(logConnectionClose));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.InternalTerminationSignal"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder InternalTerminationSignal(int? internalTerminationSignal)
-    {
-        Target.InternalTerminationSignal = internalTerminationSignal ?? throw new ArgumentNullException(nameof(internalTerminationSignal));
+        Target.ApiVersionFallbackMs = apiVersionFallbackMs ?? throw new ArgumentNullException(nameof(apiVersionFallbackMs));
         return this;
     }
 
@@ -1030,11 +889,11 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ApiVersionFallbackMs"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.BrokerAddressFamily"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder ApiVersionFallbackMs(int? apiVersionFallbackMs)
+    public KafkaMessageBusOptionsBuilder BrokerAddressFamily(BrokerAddressFamily? brokerAddressFamily)
     {
-        Target.ApiVersionFallbackMs = apiVersionFallbackMs ?? throw new ArgumentNullException(nameof(apiVersionFallbackMs));
+        Target.BrokerAddressFamily = brokerAddressFamily ?? throw new ArgumentNullException(nameof(brokerAddressFamily));
         return this;
     }
 
@@ -1048,11 +907,650 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ClientDnsLookup"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ClientDnsLookup(ClientDnsLookup? clientDnsLookup)
+    {
+        Target.ClientDnsLookup = clientDnsLookup;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ClientId"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ClientId(string clientId)
+    {
+        Target.ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ClientRack"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ClientRack(string clientRack)
+    {
+        Target.ClientRack = clientRack ?? throw new ArgumentNullException(nameof(clientRack));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ConnectionsMaxIdleMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ConnectionsMaxIdleMs(int? connectionsMaxIdleMs)
+    {
+        Target.ConnectionsMaxIdleMs = connectionsMaxIdleMs ?? throw new ArgumentNullException(nameof(connectionsMaxIdleMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.Debug"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder Debug(string debug)
+    {
+        Target.Debug = debug ?? throw new ArgumentNullException(nameof(debug));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableMetricsPush"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableMetricsPush(bool? enableMetricsPush)
+    {
+        Target.EnableMetricsPush = enableMetricsPush;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableRandomSeed"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableRandomSeed(bool? enableRandomSeed)
+    {
+        Target.EnableRandomSeed = enableRandomSeed ?? throw new ArgumentNullException(nameof(enableRandomSeed));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableSaslOauthbearerUnsecureJwt"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableSaslOauthbearerUnsecureJwt(bool? enableSaslOauthbearerUnsecureJwt)
+    {
+        Target.EnableSaslOauthbearerUnsecureJwt = enableSaslOauthbearerUnsecureJwt ?? throw new ArgumentNullException(nameof(enableSaslOauthbearerUnsecureJwt));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableSslCertificateVerification"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableSslCertificateVerification(bool? enableSslCertificateVerification)
+    {
+        Target.EnableSslCertificateVerification = enableSslCertificateVerification ?? throw new ArgumentNullException(nameof(enableSslCertificateVerification));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.HttpsCaLocation"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder HttpsCaLocation(string? httpsCaLocation)
+    {
+        Target.HttpsCaLocation = httpsCaLocation ?? throw new ArgumentNullException(nameof(httpsCaLocation));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.HttpsCaPem"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder HttpsCaPem(string? httpsCaPem)
+    {
+        Target.HttpsCaPem = httpsCaPem ?? throw new ArgumentNullException(nameof(httpsCaPem));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.InternalTerminationSignal"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder InternalTerminationSignal(int? internalTerminationSignal)
+    {
+        Target.InternalTerminationSignal = internalTerminationSignal ?? throw new ArgumentNullException(nameof(internalTerminationSignal));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.LogConnectionClose"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder LogConnectionClose(bool? logConnectionClose)
+    {
+        Target.LogConnectionClose = logConnectionClose ?? throw new ArgumentNullException(nameof(logConnectionClose));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.LogQueue"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder LogQueue(bool? logQueue)
+    {
+        Target.LogQueue = logQueue ?? throw new ArgumentNullException(nameof(logQueue));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.LogThreadName"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder LogThreadName(bool? logThreadName)
+    {
+        Target.LogThreadName = logThreadName ?? throw new ArgumentNullException(nameof(logThreadName));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MaxInFlight"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MaxInFlight(int? maxInFlight)
+    {
+        Target.MaxInFlight = maxInFlight ?? throw new ArgumentNullException(nameof(maxInFlight));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MessageCopyMaxBytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MessageCopyMaxBytes(int? messageCopyMaxBytes)
+    {
+        Target.MessageCopyMaxBytes = messageCopyMaxBytes ?? throw new ArgumentNullException(nameof(messageCopyMaxBytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MessageMaxBytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MessageMaxBytes(int? messageMaxBytes)
+    {
+        Target.MessageMaxBytes = messageMaxBytes ?? throw new ArgumentNullException(nameof(messageMaxBytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MetadataMaxAgeMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MetadataMaxAgeMs(int? metadataMaxAgeMs)
+    {
+        Target.MetadataMaxAgeMs = metadataMaxAgeMs ?? throw new ArgumentNullException(nameof(metadataMaxAgeMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MetadataRecoveryRebootstrapTriggerMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MetadataRecoveryRebootstrapTriggerMs(int? metadataRecoveryRebootstrapTriggerMs)
+    {
+        Target.MetadataRecoveryRebootstrapTriggerMs = metadataRecoveryRebootstrapTriggerMs;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MetadataRecoveryStrategy"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MetadataRecoveryStrategy(MetadataRecoveryStrategy? metadataRecoveryStrategy)
+    {
+        Target.MetadataRecoveryStrategy = metadataRecoveryStrategy;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.PluginLibraryPaths"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder PluginLibraryPaths(string pluginLibraryPaths)
+    {
+        Target.PluginLibraryPaths = pluginLibraryPaths ?? throw new ArgumentNullException(nameof(pluginLibraryPaths));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ReceiveMessageMaxBytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ReceiveMessageMaxBytes(int? receiveMessageMaxBytes)
+    {
+        Target.ReceiveMessageMaxBytes = receiveMessageMaxBytes ?? throw new ArgumentNullException(nameof(receiveMessageMaxBytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ReconnectBackoffMaxMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ReconnectBackoffMaxMs(int? reconnectBackoffMaxMs)
+    {
+        Target.ReconnectBackoffMaxMs = reconnectBackoffMaxMs ?? throw new ArgumentNullException(nameof(reconnectBackoffMaxMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ReconnectBackoffMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder ReconnectBackoffMs(int? reconnectBackoffMs)
+    {
+        Target.ReconnectBackoffMs = reconnectBackoffMs ?? throw new ArgumentNullException(nameof(reconnectBackoffMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.RetryBackoffMaxMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder RetryBackoffMaxMs(int? retryBackoffMaxMs)
+    {
+        Target.RetryBackoffMaxMs = retryBackoffMaxMs;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.RetryBackoffMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder RetryBackoffMs(int? retryBackoffMs)
+    {
+        Target.RetryBackoffMs = retryBackoffMs ?? throw new ArgumentNullException(nameof(retryBackoffMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosKeytab"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslKerberosKeytab(string saslKerberosKeytab)
+    {
+        Target.SaslKerberosKeytab = saslKerberosKeytab ?? throw new ArgumentNullException(nameof(saslKerberosKeytab));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosKinitCmd"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslKerberosKinitCmd(string saslKerberosKinitCmd)
+    {
+        Target.SaslKerberosKinitCmd = saslKerberosKinitCmd ?? throw new ArgumentNullException(nameof(saslKerberosKinitCmd));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosMinTimeBeforeRelogin"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslKerberosMinTimeBeforeRelogin(int? saslKerberosMinTimeBeforeRelogin)
+    {
+        Target.SaslKerberosMinTimeBeforeRelogin = saslKerberosMinTimeBeforeRelogin ?? throw new ArgumentNullException(nameof(saslKerberosMinTimeBeforeRelogin));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosPrincipal"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslKerberosPrincipal(string saslKerberosPrincipal)
+    {
+        Target.SaslKerberosPrincipal = saslKerberosPrincipal ?? throw new ArgumentNullException(nameof(saslKerberosPrincipal));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosServiceName"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslKerberosServiceName(string saslKerberosServiceName)
+    {
+        Target.SaslKerberosServiceName = saslKerberosServiceName ?? throw new ArgumentNullException(nameof(saslKerberosServiceName));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslMechanism"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslMechanism(SaslMechanism? saslMechanism)
+    {
+        Target.SaslMechanism = saslMechanism ?? throw new ArgumentNullException(nameof(saslMechanism));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionAlgorithm"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionAlgorithm(SaslOauthbearerAssertionAlgorithm? saslOauthbearerAssertionAlgorithm)
+    {
+        Target.SaslOauthbearerAssertionAlgorithm = saslOauthbearerAssertionAlgorithm;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionClaimAud"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionClaimAud(string? saslOauthbearerAssertionClaimAud)
+    {
+        Target.SaslOauthbearerAssertionClaimAud = saslOauthbearerAssertionClaimAud ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionClaimAud));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionClaimExpSeconds"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionClaimExpSeconds(int? saslOauthbearerAssertionClaimExpSeconds)
+    {
+        Target.SaslOauthbearerAssertionClaimExpSeconds = saslOauthbearerAssertionClaimExpSeconds;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionClaimIss"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionClaimIss(string? saslOauthbearerAssertionClaimIss)
+    {
+        Target.SaslOauthbearerAssertionClaimIss = saslOauthbearerAssertionClaimIss ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionClaimIss));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionClaimJtiInclude"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionClaimJtiInclude(bool? saslOauthbearerAssertionClaimJtiInclude)
+    {
+        Target.SaslOauthbearerAssertionClaimJtiInclude = saslOauthbearerAssertionClaimJtiInclude;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionClaimNbfSeconds"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionClaimNbfSeconds(int? saslOauthbearerAssertionClaimNbfSeconds)
+    {
+        Target.SaslOauthbearerAssertionClaimNbfSeconds = saslOauthbearerAssertionClaimNbfSeconds;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionClaimSub"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionClaimSub(string? saslOauthbearerAssertionClaimSub)
+    {
+        Target.SaslOauthbearerAssertionClaimSub = saslOauthbearerAssertionClaimSub ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionClaimSub));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionFile"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionFile(string? saslOauthbearerAssertionFile)
+    {
+        Target.SaslOauthbearerAssertionFile = saslOauthbearerAssertionFile ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionFile));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionJwtTemplateFile"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionJwtTemplateFile(string? saslOauthbearerAssertionJwtTemplateFile)
+    {
+        Target.SaslOauthbearerAssertionJwtTemplateFile = saslOauthbearerAssertionJwtTemplateFile ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionJwtTemplateFile));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionPrivateKeyFile"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionPrivateKeyFile(string? saslOauthbearerAssertionPrivateKeyFile)
+    {
+        Target.SaslOauthbearerAssertionPrivateKeyFile = saslOauthbearerAssertionPrivateKeyFile ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionPrivateKeyFile));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionPrivateKeyPassphrase"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionPrivateKeyPassphrase(string? saslOauthbearerAssertionPrivateKeyPassphrase)
+    {
+        Target.SaslOauthbearerAssertionPrivateKeyPassphrase = saslOauthbearerAssertionPrivateKeyPassphrase ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionPrivateKeyPassphrase));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerAssertionPrivateKeyPem"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerAssertionPrivateKeyPem(string? saslOauthbearerAssertionPrivateKeyPem)
+    {
+        Target.SaslOauthbearerAssertionPrivateKeyPem = saslOauthbearerAssertionPrivateKeyPem ?? throw new ArgumentNullException(nameof(saslOauthbearerAssertionPrivateKeyPem));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerClientId"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerClientId(string? saslOauthbearerClientId)
+    {
+        Target.SaslOauthbearerClientId = saslOauthbearerClientId ?? throw new ArgumentNullException(nameof(saslOauthbearerClientId));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerClientSecret"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerClientSecret(string? saslOauthbearerClientSecret)
+    {
+        Target.SaslOauthbearerClientSecret = saslOauthbearerClientSecret ?? throw new ArgumentNullException(nameof(saslOauthbearerClientSecret));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerConfig"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerConfig(string saslOauthbearerConfig)
+    {
+        Target.SaslOauthbearerConfig = saslOauthbearerConfig ?? throw new ArgumentNullException(nameof(saslOauthbearerConfig));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerExtensions"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerExtensions(string? saslOauthbearerExtensions)
+    {
+        Target.SaslOauthbearerExtensions = saslOauthbearerExtensions ?? throw new ArgumentNullException(nameof(saslOauthbearerExtensions));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerGrantType"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerGrantType(SaslOauthbearerGrantType? saslOauthbearerGrantType)
+    {
+        Target.SaslOauthbearerGrantType = saslOauthbearerGrantType;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerMetadataAuthenticationType"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerMetadataAuthenticationType(SaslOauthbearerMetadataAuthenticationType? saslOauthbearerMetadataAuthenticationType)
+    {
+        Target.SaslOauthbearerMetadataAuthenticationType = saslOauthbearerMetadataAuthenticationType;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerMethod"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerMethod(SaslOauthbearerMethod? saslOauthbearerMethod)
+    {
+        Target.SaslOauthbearerMethod = saslOauthbearerMethod;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerScope"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerScope(string? saslOauthbearerScope)
+    {
+        Target.SaslOauthbearerScope = saslOauthbearerScope ?? throw new ArgumentNullException(nameof(saslOauthbearerScope));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerSubClaimName"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerSubClaimName(string? saslOauthbearerSubClaimName)
+    {
+        Target.SaslOauthbearerSubClaimName = saslOauthbearerSubClaimName ?? throw new ArgumentNullException(nameof(saslOauthbearerSubClaimName));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerTokenEndpointUrl"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslOauthbearerTokenEndpointUrl(string? saslOauthbearerTokenEndpointUrl)
+    {
+        Target.SaslOauthbearerTokenEndpointUrl = saslOauthbearerTokenEndpointUrl ?? throw new ArgumentNullException(nameof(saslOauthbearerTokenEndpointUrl));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslPassword"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslPassword(string saslPassword)
+    {
+        Target.SaslPassword = saslPassword ?? throw new ArgumentNullException(nameof(saslPassword));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SaslUsername"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SaslUsername(string saslUsername)
+    {
+        Target.SaslUsername = saslUsername ?? throw new ArgumentNullException(nameof(saslUsername));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SecurityProtocol"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SecurityProtocol(SecurityProtocol? securityProtocol)
+    {
+        Target.SecurityProtocol = securityProtocol ?? throw new ArgumentNullException(nameof(securityProtocol));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketConnectionSetupTimeoutMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketConnectionSetupTimeoutMs(int? socketConnectionSetupTimeoutMs)
+    {
+        Target.SocketConnectionSetupTimeoutMs = socketConnectionSetupTimeoutMs;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketKeepaliveEnable"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketKeepaliveEnable(bool? socketKeepaliveEnable)
+    {
+        Target.SocketKeepaliveEnable = socketKeepaliveEnable ?? throw new ArgumentNullException(nameof(socketKeepaliveEnable));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketMaxFails"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketMaxFails(int? socketMaxFails)
+    {
+        Target.SocketMaxFails = socketMaxFails ?? throw new ArgumentNullException(nameof(socketMaxFails));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketNagleDisable"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketNagleDisable(bool? socketNagleDisable)
+    {
+        Target.SocketNagleDisable = socketNagleDisable ?? throw new ArgumentNullException(nameof(socketNagleDisable));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketReceiveBufferBytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketReceiveBufferBytes(int? socketReceiveBufferBytes)
+    {
+        Target.SocketReceiveBufferBytes = socketReceiveBufferBytes ?? throw new ArgumentNullException(nameof(socketReceiveBufferBytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketSendBufferBytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketSendBufferBytes(int? socketSendBufferBytes)
+    {
+        Target.SocketSendBufferBytes = socketSendBufferBytes ?? throw new ArgumentNullException(nameof(socketSendBufferBytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SocketTimeoutMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SocketTimeoutMs(int? socketTimeoutMs)
+    {
+        Target.SocketTimeoutMs = socketTimeoutMs ?? throw new ArgumentNullException(nameof(socketTimeoutMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslCaCertificateStores"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslCaCertificateStores(string sslCaCertificateStores)
+    {
+        Target.SslCaCertificateStores = sslCaCertificateStores ?? throw new ArgumentNullException(nameof(sslCaCertificateStores));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslCaLocation"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslCaLocation(string sslCaLocation)
+    {
+        Target.SslCaLocation = sslCaLocation ?? throw new ArgumentNullException(nameof(sslCaLocation));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslCaPem"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslCaPem(string sslCaPem)
+    {
+        Target.SslCaPem = sslCaPem ?? throw new ArgumentNullException(nameof(sslCaPem));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslCertificateLocation"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslCertificateLocation(string sslCertificateLocation)
+    {
+        Target.SslCertificateLocation = sslCertificateLocation ?? throw new ArgumentNullException(nameof(sslCertificateLocation));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslCertificatePem"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslCertificatePem(string sslCertificatePem)
+    {
+        Target.SslCertificatePem = sslCertificatePem ?? throw new ArgumentNullException(nameof(sslCertificatePem));
+        return this;
+    }
+
+    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.SslCipherSuites"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder SslCipherSuites(string sslCipherSuites)
     {
         Target.SslCipherSuites = sslCipherSuites ?? throw new ArgumentNullException(nameof(sslCipherSuites));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslCrlLocation"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslCrlLocation(string sslCrlLocation)
+    {
+        Target.SslCrlLocation = sslCrlLocation ?? throw new ArgumentNullException(nameof(sslCrlLocation));
         return this;
     }
 
@@ -1066,11 +1564,29 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslSigalgsList"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslEndpointIdentificationAlgorithm"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SslSigalgsList(string sslSigalgsList)
+    public KafkaMessageBusOptionsBuilder SslEndpointIdentificationAlgorithm(SslEndpointIdentificationAlgorithm? sslEndpointIdentificationAlgorithm)
     {
-        Target.SslSigalgsList = sslSigalgsList ?? throw new ArgumentNullException(nameof(sslSigalgsList));
+        Target.SslEndpointIdentificationAlgorithm = sslEndpointIdentificationAlgorithm ?? throw new ArgumentNullException(nameof(sslEndpointIdentificationAlgorithm));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslEngineId"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslEngineId(string sslEngineId)
+    {
+        Target.SslEngineId = sslEngineId ?? throw new ArgumentNullException(nameof(sslEngineId));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslEngineLocation"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SslEngineLocation(string sslEngineLocation)
+    {
+        Target.SslEngineLocation = sslEngineLocation ?? throw new ArgumentNullException(nameof(sslEngineLocation));
         return this;
     }
 
@@ -1102,42 +1618,6 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslCertificatePem"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SslCertificatePem(string sslCertificatePem)
-    {
-        Target.SslCertificatePem = sslCertificatePem ?? throw new ArgumentNullException(nameof(sslCertificatePem));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslCaPem"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SslCaPem(string sslCaPem)
-    {
-        Target.SslCaPem = sslCaPem ?? throw new ArgumentNullException(nameof(sslCaPem));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslCaCertificateStores"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SslCaCertificateStores(string sslCaCertificateStores)
-    {
-        Target.SslCaCertificateStores = sslCaCertificateStores ?? throw new ArgumentNullException(nameof(sslCaCertificateStores));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslCrlLocation"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SslCrlLocation(string sslCrlLocation)
-    {
-        Target.SslCrlLocation = sslCrlLocation ?? throw new ArgumentNullException(nameof(sslCrlLocation));
-        return this;
-    }
-
-    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.SslKeystoreLocation"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder SslKeystoreLocation(string sslKeystoreLocation)
@@ -1156,281 +1636,74 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslEngineLocation"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslProviders"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SslEngineLocation(string sslEngineLocation)
+    public KafkaMessageBusOptionsBuilder SslProviders(string? sslProviders)
     {
-        Target.SslEngineLocation = sslEngineLocation ?? throw new ArgumentNullException(nameof(sslEngineLocation));
+        Target.SslProviders = sslProviders ?? throw new ArgumentNullException(nameof(sslProviders));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslEngineId"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SslSigalgsList"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SslEngineId(string sslEngineId)
+    public KafkaMessageBusOptionsBuilder SslSigalgsList(string sslSigalgsList)
     {
-        Target.SslEngineId = sslEngineId ?? throw new ArgumentNullException(nameof(sslEngineId));
+        Target.SslSigalgsList = sslSigalgsList ?? throw new ArgumentNullException(nameof(sslSigalgsList));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableSslCertificateVerification"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.StatisticsIntervalMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableSslCertificateVerification(bool? enableSslCertificateVerification)
+    public KafkaMessageBusOptionsBuilder StatisticsIntervalMs(int? statisticsIntervalMs)
     {
-        Target.EnableSslCertificateVerification = enableSslCertificateVerification ?? throw new ArgumentNullException(nameof(enableSslCertificateVerification));
+        Target.StatisticsIntervalMs = statisticsIntervalMs ?? throw new ArgumentNullException(nameof(statisticsIntervalMs));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SslEndpointIdentificationAlgorithm"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TopicBlacklist"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SslEndpointIdentificationAlgorithm(SslEndpointIdentificationAlgorithm? sslEndpointIdentificationAlgorithm)
+    public KafkaMessageBusOptionsBuilder TopicBlacklist(string topicBlacklist)
     {
-        Target.SslEndpointIdentificationAlgorithm = sslEndpointIdentificationAlgorithm ?? throw new ArgumentNullException(nameof(sslEndpointIdentificationAlgorithm));
+        Target.TopicBlacklist = topicBlacklist ?? throw new ArgumentNullException(nameof(topicBlacklist));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosServiceName"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataPropagationMaxMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslKerberosServiceName(string saslKerberosServiceName)
+    public KafkaMessageBusOptionsBuilder TopicMetadataPropagationMaxMs(int? topicMetadataPropagationMaxMs)
     {
-        Target.SaslKerberosServiceName = saslKerberosServiceName ?? throw new ArgumentNullException(nameof(saslKerberosServiceName));
+        Target.TopicMetadataPropagationMaxMs = topicMetadataPropagationMaxMs ?? throw new ArgumentNullException(nameof(topicMetadataPropagationMaxMs));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosPrincipal"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataRefreshFastIntervalMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslKerberosPrincipal(string saslKerberosPrincipal)
+    public KafkaMessageBusOptionsBuilder TopicMetadataRefreshFastIntervalMs(int? topicMetadataRefreshFastIntervalMs)
     {
-        Target.SaslKerberosPrincipal = saslKerberosPrincipal ?? throw new ArgumentNullException(nameof(saslKerberosPrincipal));
+        Target.TopicMetadataRefreshFastIntervalMs = topicMetadataRefreshFastIntervalMs ?? throw new ArgumentNullException(nameof(topicMetadataRefreshFastIntervalMs));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosKinitCmd"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataRefreshIntervalMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslKerberosKinitCmd(string saslKerberosKinitCmd)
+    public KafkaMessageBusOptionsBuilder TopicMetadataRefreshIntervalMs(int? topicMetadataRefreshIntervalMs)
     {
-        Target.SaslKerberosKinitCmd = saslKerberosKinitCmd ?? throw new ArgumentNullException(nameof(saslKerberosKinitCmd));
+        Target.TopicMetadataRefreshIntervalMs = topicMetadataRefreshIntervalMs ?? throw new ArgumentNullException(nameof(topicMetadataRefreshIntervalMs));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosKeytab"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TopicMetadataRefreshSparse"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslKerberosKeytab(string saslKerberosKeytab)
+    public KafkaMessageBusOptionsBuilder TopicMetadataRefreshSparse(bool? topicMetadataRefreshSparse)
     {
-        Target.SaslKerberosKeytab = saslKerberosKeytab ?? throw new ArgumentNullException(nameof(saslKerberosKeytab));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslKerberosMinTimeBeforeRelogin"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslKerberosMinTimeBeforeRelogin(int? saslKerberosMinTimeBeforeRelogin)
-    {
-        Target.SaslKerberosMinTimeBeforeRelogin = saslKerberosMinTimeBeforeRelogin ?? throw new ArgumentNullException(nameof(saslKerberosMinTimeBeforeRelogin));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SaslOauthbearerConfig"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SaslOauthbearerConfig(string saslOauthbearerConfig)
-    {
-        Target.SaslOauthbearerConfig = saslOauthbearerConfig ?? throw new ArgumentNullException(nameof(saslOauthbearerConfig));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableSaslOauthbearerUnsecureJwt"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableSaslOauthbearerUnsecureJwt(bool? enableSaslOauthbearerUnsecureJwt)
-    {
-        Target.EnableSaslOauthbearerUnsecureJwt = enableSaslOauthbearerUnsecureJwt ?? throw new ArgumentNullException(nameof(enableSaslOauthbearerUnsecureJwt));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.PluginLibraryPaths"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder PluginLibraryPaths(string pluginLibraryPaths)
-    {
-        Target.PluginLibraryPaths = pluginLibraryPaths ?? throw new ArgumentNullException(nameof(pluginLibraryPaths));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ClientRack"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder ClientRack(string clientRack)
-    {
-        Target.ClientRack = clientRack ?? throw new ArgumentNullException(nameof(clientRack));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableBackgroundPoll"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableBackgroundPoll(bool? enableBackgroundPoll)
-    {
-        Target.EnableBackgroundPoll = enableBackgroundPoll ?? throw new ArgumentNullException(nameof(enableBackgroundPoll));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableDeliveryReports"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableDeliveryReports(bool? enableDeliveryReports)
-    {
-        Target.EnableDeliveryReports = enableDeliveryReports ?? throw new ArgumentNullException(nameof(enableDeliveryReports));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.DeliveryReportFields"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder DeliveryReportFields(string deliveryReportFields)
-    {
-        Target.DeliveryReportFields = deliveryReportFields ?? throw new ArgumentNullException(nameof(deliveryReportFields));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.RequestTimeoutMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder RequestTimeoutMs(int? requestTimeoutMs)
-    {
-        Target.RequestTimeoutMs = requestTimeoutMs ?? throw new ArgumentNullException(nameof(requestTimeoutMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MessageTimeoutMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MessageTimeoutMs(int? messageTimeoutMs)
-    {
-        Target.MessageTimeoutMs = messageTimeoutMs ?? throw new ArgumentNullException(nameof(messageTimeoutMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.Partitioner"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder Partitioner(Partitioner? partitioner)
-    {
-        Target.Partitioner = partitioner ?? throw new ArgumentNullException(nameof(partitioner));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.CompressionLevel"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder CompressionLevel(int? compressionLevel)
-    {
-        Target.CompressionLevel = compressionLevel ?? throw new ArgumentNullException(nameof(compressionLevel));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TransactionalId"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TransactionalId(string transactionalId)
-    {
-        Target.TransactionalId = transactionalId ?? throw new ArgumentNullException(nameof(transactionalId));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.TransactionTimeoutMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder TransactionTimeoutMs(int? transactionTimeoutMs)
-    {
-        Target.TransactionTimeoutMs = transactionTimeoutMs ?? throw new ArgumentNullException(nameof(transactionTimeoutMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableIdempotence"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableIdempotence(bool? enableIdempotence)
-    {
-        Target.EnableIdempotence = enableIdempotence ?? throw new ArgumentNullException(nameof(enableIdempotence));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnableGaplessGuarantee"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder EnableGaplessGuarantee(bool? enableGaplessGuarantee)
-    {
-        Target.EnableGaplessGuarantee = enableGaplessGuarantee ?? throw new ArgumentNullException(nameof(enableGaplessGuarantee));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.QueueBufferingMaxMessages"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder QueueBufferingMaxMessages(int? queueBufferingMaxMessages)
-    {
-        Target.QueueBufferingMaxMessages = queueBufferingMaxMessages ?? throw new ArgumentNullException(nameof(queueBufferingMaxMessages));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.QueueBufferingMaxKbytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder QueueBufferingMaxKbytes(int? queueBufferingMaxKbytes)
-    {
-        Target.QueueBufferingMaxKbytes = queueBufferingMaxKbytes ?? throw new ArgumentNullException(nameof(queueBufferingMaxKbytes));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.LingerMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder LingerMs(double? lingerMs)
-    {
-        Target.LingerMs = lingerMs ?? throw new ArgumentNullException(nameof(lingerMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MessageSendMaxRetries"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MessageSendMaxRetries(int? messageSendMaxRetries)
-    {
-        Target.MessageSendMaxRetries = messageSendMaxRetries ?? throw new ArgumentNullException(nameof(messageSendMaxRetries));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.RetryBackoffMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder RetryBackoffMs(int? retryBackoffMs)
-    {
-        Target.RetryBackoffMs = retryBackoffMs ?? throw new ArgumentNullException(nameof(retryBackoffMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.QueueBufferingBackpressureThreshold"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder QueueBufferingBackpressureThreshold(int? queueBufferingBackpressureThreshold)
-    {
-        Target.QueueBufferingBackpressureThreshold = queueBufferingBackpressureThreshold ?? throw new ArgumentNullException(nameof(queueBufferingBackpressureThreshold));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.CompressionType"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder CompressionType(CompressionType? compressionType)
-    {
-        Target.CompressionType = compressionType ?? throw new ArgumentNullException(nameof(compressionType));
+        Target.TopicMetadataRefreshSparse = topicMetadataRefreshSparse ?? throw new ArgumentNullException(nameof(topicMetadataRefreshSparse));
         return this;
     }
 
@@ -1453,6 +1726,141 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.CompressionLevel"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder CompressionLevel(int? compressionLevel)
+    {
+        Target.CompressionLevel = compressionLevel ?? throw new ArgumentNullException(nameof(compressionLevel));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.CompressionType"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder CompressionType(CompressionType? compressionType)
+    {
+        Target.CompressionType = compressionType ?? throw new ArgumentNullException(nameof(compressionType));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.DeliveryReportFields"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder DeliveryReportFields(string deliveryReportFields)
+    {
+        Target.DeliveryReportFields = deliveryReportFields ?? throw new ArgumentNullException(nameof(deliveryReportFields));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableBackgroundPoll"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableBackgroundPoll(bool? enableBackgroundPoll)
+    {
+        Target.EnableBackgroundPoll = enableBackgroundPoll ?? throw new ArgumentNullException(nameof(enableBackgroundPoll));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableDeliveryReports"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableDeliveryReports(bool? enableDeliveryReports)
+    {
+        Target.EnableDeliveryReports = enableDeliveryReports ?? throw new ArgumentNullException(nameof(enableDeliveryReports));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableGaplessGuarantee"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableGaplessGuarantee(bool? enableGaplessGuarantee)
+    {
+        Target.EnableGaplessGuarantee = enableGaplessGuarantee ?? throw new ArgumentNullException(nameof(enableGaplessGuarantee));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnableIdempotence"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder EnableIdempotence(bool? enableIdempotence)
+    {
+        Target.EnableIdempotence = enableIdempotence ?? throw new ArgumentNullException(nameof(enableIdempotence));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.LingerMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder LingerMs(double? lingerMs)
+    {
+        Target.LingerMs = lingerMs ?? throw new ArgumentNullException(nameof(lingerMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MessageSendMaxRetries"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MessageSendMaxRetries(int? messageSendMaxRetries)
+    {
+        Target.MessageSendMaxRetries = messageSendMaxRetries ?? throw new ArgumentNullException(nameof(messageSendMaxRetries));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MessageTimeoutMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder MessageTimeoutMs(int? messageTimeoutMs)
+    {
+        Target.MessageTimeoutMs = messageTimeoutMs ?? throw new ArgumentNullException(nameof(messageTimeoutMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.Partitioner"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder Partitioner(Partitioner? partitioner)
+    {
+        Target.Partitioner = partitioner ?? throw new ArgumentNullException(nameof(partitioner));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.QueueBufferingBackpressureThreshold"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder QueueBufferingBackpressureThreshold(int? queueBufferingBackpressureThreshold)
+    {
+        Target.QueueBufferingBackpressureThreshold = queueBufferingBackpressureThreshold ?? throw new ArgumentNullException(nameof(queueBufferingBackpressureThreshold));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.QueueBufferingMaxKbytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder QueueBufferingMaxKbytes(int? queueBufferingMaxKbytes)
+    {
+        Target.QueueBufferingMaxKbytes = queueBufferingMaxKbytes ?? throw new ArgumentNullException(nameof(queueBufferingMaxKbytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.QueueBufferingMaxMessages"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder QueueBufferingMaxMessages(int? queueBufferingMaxMessages)
+    {
+        Target.QueueBufferingMaxMessages = queueBufferingMaxMessages ?? throw new ArgumentNullException(nameof(queueBufferingMaxMessages));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.RequestTimeoutMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder RequestTimeoutMs(int? requestTimeoutMs)
+    {
+        Target.RequestTimeoutMs = requestTimeoutMs ?? throw new ArgumentNullException(nameof(requestTimeoutMs));
+        return this;
+    }
+
+    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.StickyPartitioningLingerMs"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder StickyPartitioningLingerMs(int? stickyPartitioningLingerMs)
@@ -1462,11 +1870,29 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.ConsumeResultFields"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TransactionTimeoutMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder ConsumeResultFields(string consumeResultFields)
+    public KafkaMessageBusOptionsBuilder TransactionTimeoutMs(int? transactionTimeoutMs)
     {
-        Target.ConsumeResultFields = consumeResultFields ?? throw new ArgumentNullException(nameof(consumeResultFields));
+        Target.TransactionTimeoutMs = transactionTimeoutMs ?? throw new ArgumentNullException(nameof(transactionTimeoutMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.TransactionalId"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder TransactionalId(string transactionalId)
+    {
+        Target.TransactionalId = transactionalId ?? throw new ArgumentNullException(nameof(transactionalId));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.AutoCommitIntervalMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder AutoCommitIntervalMs(int autoCommitIntervalMs)
+    {
+        Target.AutoCommitIntervalMs = autoCommitIntervalMs;
         return this;
     }
 
@@ -1480,47 +1906,20 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.GroupInstanceId"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.CheckCrcs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder GroupInstanceId(string groupInstanceId)
+    public KafkaMessageBusOptionsBuilder CheckCrcs(bool? checkCrcs)
     {
-        Target.GroupInstanceId = groupInstanceId ?? throw new ArgumentNullException(nameof(groupInstanceId));
+        Target.CheckCrcs = checkCrcs ?? throw new ArgumentNullException(nameof(checkCrcs));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.PartitionAssignmentStrategy"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.ConsumeResultFields"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder PartitionAssignmentStrategy(PartitionAssignmentStrategy? partitionAssignmentStrategy)
+    public KafkaMessageBusOptionsBuilder ConsumeResultFields(string consumeResultFields)
     {
-        Target.PartitionAssignmentStrategy = partitionAssignmentStrategy ?? throw new ArgumentNullException(nameof(partitionAssignmentStrategy));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.SessionTimeoutMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder SessionTimeoutMs(int? sessionTimeoutMs)
-    {
-        Target.SessionTimeoutMs = sessionTimeoutMs ?? throw new ArgumentNullException(nameof(sessionTimeoutMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.HeartbeatIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder HeartbeatIntervalMs(int? heartbeatIntervalMs)
-    {
-        Target.HeartbeatIntervalMs = heartbeatIntervalMs ?? throw new ArgumentNullException(nameof(heartbeatIntervalMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.GroupProtocolType"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder GroupProtocolType(string groupProtocolType)
-    {
-        Target.GroupProtocolType = groupProtocolType ?? throw new ArgumentNullException(nameof(groupProtocolType));
+        Target.ConsumeResultFields = consumeResultFields ?? throw new ArgumentNullException(nameof(consumeResultFields));
         return this;
     }
 
@@ -1530,15 +1929,6 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     public KafkaMessageBusOptionsBuilder CoordinatorQueryIntervalMs(int? coordinatorQueryIntervalMs)
     {
         Target.CoordinatorQueryIntervalMs = coordinatorQueryIntervalMs ?? throw new ArgumentNullException(nameof(coordinatorQueryIntervalMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MaxPollIntervalMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MaxPollIntervalMs(int? maxPollIntervalMs)
-    {
-        Target.MaxPollIntervalMs = maxPollIntervalMs ?? throw new ArgumentNullException(nameof(maxPollIntervalMs));
         return this;
     }
 
@@ -1561,20 +1951,11 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.QueuedMinMessages"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.EnablePartitionEof"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder QueuedMinMessages(int? queuedMinMessages)
+    public KafkaMessageBusOptionsBuilder EnablePartitionEof(bool? enablePartitionEof)
     {
-        Target.QueuedMinMessages = queuedMinMessages ?? throw new ArgumentNullException(nameof(queuedMinMessages));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.QueuedMaxMessagesKbytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder QueuedMaxMessagesKbytes(int? queuedMaxMessagesKbytes)
-    {
-        Target.QueuedMaxMessagesKbytes = queuedMaxMessagesKbytes ?? throw new ArgumentNullException(nameof(queuedMaxMessagesKbytes));
+        Target.EnablePartitionEof = enablePartitionEof ?? throw new ArgumentNullException(nameof(enablePartitionEof));
         return this;
     }
 
@@ -1584,24 +1965,6 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     public KafkaMessageBusOptionsBuilder FetchErrorBackoffMs(int? fetchErrorBackoffMs)
     {
         Target.FetchErrorBackoffMs = fetchErrorBackoffMs ?? throw new ArgumentNullException(nameof(fetchErrorBackoffMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.FetchWaitMaxMs"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder FetchWaitMaxMs(int? fetchWaitMaxMs)
-    {
-        Target.FetchWaitMaxMs = fetchWaitMaxMs ?? throw new ArgumentNullException(nameof(fetchWaitMaxMs));
-        return this;
-    }
-
-    /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.MaxPartitionFetchBytes"/>
-    /// </summary>
-    public KafkaMessageBusOptionsBuilder MaxPartitionFetchBytes(int? maxPartitionFetchBytes)
-    {
-        Target.MaxPartitionFetchBytes = maxPartitionFetchBytes ?? throw new ArgumentNullException(nameof(maxPartitionFetchBytes));
         return this;
     }
 
@@ -1624,6 +1987,69 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.FetchQueueBackoffMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder FetchQueueBackoffMs(int? fetchQueueBackoffMs)
+    {
+        Target.FetchQueueBackoffMs = fetchQueueBackoffMs;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.FetchWaitMaxMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder FetchWaitMaxMs(int? fetchWaitMaxMs)
+    {
+        Target.FetchWaitMaxMs = fetchWaitMaxMs ?? throw new ArgumentNullException(nameof(fetchWaitMaxMs));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.GroupInstanceId"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder GroupInstanceId(string groupInstanceId)
+    {
+        Target.GroupInstanceId = groupInstanceId ?? throw new ArgumentNullException(nameof(groupInstanceId));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.GroupProtocol"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder GroupProtocol(GroupProtocol? groupProtocol)
+    {
+        Target.GroupProtocol = groupProtocol;
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.GroupProtocolType"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder GroupProtocolType(string groupProtocolType)
+    {
+        Target.GroupProtocolType = groupProtocolType ?? throw new ArgumentNullException(nameof(groupProtocolType));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.GroupRemoteAssignor"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder GroupRemoteAssignor(string? groupRemoteAssignor)
+    {
+        Target.GroupRemoteAssignor = groupRemoteAssignor ?? throw new ArgumentNullException(nameof(groupRemoteAssignor));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.HeartbeatIntervalMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder HeartbeatIntervalMs(int? heartbeatIntervalMs)
+    {
+        Target.HeartbeatIntervalMs = heartbeatIntervalMs ?? throw new ArgumentNullException(nameof(heartbeatIntervalMs));
+        return this;
+    }
+
+    /// <summary>
     /// <inheritdoc cref="KafkaMessageBusOptions.IsolationLevel"/>
     /// </summary>
     public KafkaMessageBusOptionsBuilder IsolationLevel(IsolationLevel? isolationLevel)
@@ -1633,29 +2059,56 @@ public class KafkaMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<Kafk
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.EnablePartitionEof"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MaxPartitionFetchBytes"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder EnablePartitionEof(bool? enablePartitionEof)
+    public KafkaMessageBusOptionsBuilder MaxPartitionFetchBytes(int? maxPartitionFetchBytes)
     {
-        Target.EnablePartitionEof = enablePartitionEof ?? throw new ArgumentNullException(nameof(enablePartitionEof));
+        Target.MaxPartitionFetchBytes = maxPartitionFetchBytes ?? throw new ArgumentNullException(nameof(maxPartitionFetchBytes));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.CheckCrcs"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.MaxPollIntervalMs"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder CheckCrcs(bool? checkCrcs)
+    public KafkaMessageBusOptionsBuilder MaxPollIntervalMs(int? maxPollIntervalMs)
     {
-        Target.CheckCrcs = checkCrcs ?? throw new ArgumentNullException(nameof(checkCrcs));
+        Target.MaxPollIntervalMs = maxPollIntervalMs ?? throw new ArgumentNullException(nameof(maxPollIntervalMs));
         return this;
     }
 
     /// <summary>
-    /// <inheritdoc cref="KafkaMessageBusOptions.AllowAutoCreateTopics"/>
+    /// <inheritdoc cref="KafkaMessageBusOptions.PartitionAssignmentStrategy"/>
     /// </summary>
-    public KafkaMessageBusOptionsBuilder AllowAutoCreateTopics(bool? allowAutoCreateTopics)
+    public KafkaMessageBusOptionsBuilder PartitionAssignmentStrategy(PartitionAssignmentStrategy? partitionAssignmentStrategy)
     {
-        Target.AllowAutoCreateTopics = allowAutoCreateTopics ?? throw new ArgumentNullException(nameof(allowAutoCreateTopics));
+        Target.PartitionAssignmentStrategy = partitionAssignmentStrategy ?? throw new ArgumentNullException(nameof(partitionAssignmentStrategy));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.QueuedMaxMessagesKbytes"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder QueuedMaxMessagesKbytes(int? queuedMaxMessagesKbytes)
+    {
+        Target.QueuedMaxMessagesKbytes = queuedMaxMessagesKbytes ?? throw new ArgumentNullException(nameof(queuedMaxMessagesKbytes));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.QueuedMinMessages"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder QueuedMinMessages(int? queuedMinMessages)
+    {
+        Target.QueuedMinMessages = queuedMinMessages ?? throw new ArgumentNullException(nameof(queuedMinMessages));
+        return this;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="KafkaMessageBusOptions.SessionTimeoutMs"/>
+    /// </summary>
+    public KafkaMessageBusOptionsBuilder SessionTimeoutMs(int? sessionTimeoutMs)
+    {
+        Target.SessionTimeoutMs = sessionTimeoutMs ?? throw new ArgumentNullException(nameof(sessionTimeoutMs));
         return this;
     }
 }


### PR DESCRIPTION
## Summary

- Align `KafkaMessageBusOptions` with Confluent.Kafka 2.14.2 by adding 33 missing configuration properties (OIDC/OAuth bearer assertions, metadata recovery, socket setup timeout, HTTPS CA, SSL providers, retry backoff max, client DNS lookup, metrics push, KIP-848 group protocol, group remote assignor, fetch queue backoff) with full builder method support
- Fix race condition in `EnsureListening()` where multiple consumer loops could be started concurrently
- Make `_topicCreated` field volatile for correct cross-thread memory visibility
- Sort all properties, builder methods, and config wiring assignments alphabetically within their sections for maintainability
- Remove duplicate `AutoCommitIntervalMs` builder overload and fix copy-paste doc comment errors

## Test plan

- [x] `dotnet build Foundatio.Kafka.slnx` passes with 0 warnings, 0 errors
- [ ] `dotnet test Foundatio.Kafka.slnx` passes (integration tests require Kafka broker)
- [ ] Verify new OIDC/OAuth properties are correctly wired through to Confluent.Kafka `ClientConfig`
- [ ] Verify `EnsureListening()` race condition fix doesn't cause deadlocks under concurrent subscription
