### PR TITLE
Upgrade to Confluent.Kafka 2.15.0 and fix EOF handling

### DIFF
--- a/src/Foundatio.Kafka/Foundatio.Kafka.csproj
+++ b/src/Foundatio.Kafka/Foundatio.Kafka.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.14.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
 
     <PackageReference Include="Foundatio" Version="13.0.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />

--- a/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
+++ b/src/Foundatio.Kafka/Messaging/KafkaMessageBus.cs
@@ -262,6 +262,12 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
                         while (!DisposedCancellationToken.IsCancellationRequested)
                         {
                             var consumeResult = consumer.Consume(DisposedCancellationToken);
+                            if (consumeResult.IsPartitionEOF)
+                            {
+                                _logger.LogTrace("Reached end of partition: {TopicPartitionOffset}", consumeResult.TopicPartitionOffset);
+                                continue;
+                            }
+
                             await OnMessageAsync(consumer, consumeResult).AnyContext();
                         }
                     }
@@ -608,7 +614,7 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusOptions>, IKafkaMes
         if (_options.BatchSize.HasValue) producerConfig.BatchSize = _options.BatchSize;
         if (_options.CompressionLevel.HasValue) producerConfig.CompressionLevel = _options.CompressionLevel;
         if (_options.CompressionType.HasValue) producerConfig.CompressionType = _options.CompressionType;
-        if (!String.IsNullOrEmpty(_options.DeliveryReportFields)) producerConfig.DeliveryReportFields = _options.DeliveryReportFields; // TODO: Producer config throws exception with this property
+        if (!String.IsNullOrEmpty(_options.DeliveryReportFields)) producerConfig.DeliveryReportFields = _options.DeliveryReportFields;
         if (_options.EnableBackgroundPoll.HasValue) producerConfig.EnableBackgroundPoll = _options.EnableBackgroundPoll;
         if (_options.EnableDeliveryReports.HasValue) producerConfig.EnableDeliveryReports = _options.EnableDeliveryReports;
         if (_options.EnableGaplessGuarantee.HasValue) producerConfig.EnableGaplessGuarantee = _options.EnableGaplessGuarantee;

--- a/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
+++ b/tests/Foundatio.Kafka.Tests/Messaging/KafkaMessageBusTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.AsyncEx;
@@ -269,5 +270,42 @@ public class KafkaMessageBusTests : KafkaMessageBusTestBase
         cts.Dispose();
 
         await CleanupMessageBusAsync(messageBus2);
+    }
+
+    [Fact]
+    public async Task CanReceiveMessagesWithPartitionEofEnabled_WhenPartitionReachesEof_DoesNotLogErrorsAsync()
+    {
+        // Arrange
+        using var messageBus = new KafkaMessageBus(o => o
+            .BootstrapServers("127.0.0.1:9092")
+            .Topic(Topic)
+            .TopicReplicationFactor(1)
+            .TopicNumberOfPartitions(1)
+            .GroupId(GroupId)
+            .AllowAutoCreateTopics(true)
+            .EnablePartitionEof(true)
+            .LoggerFactory(Log)
+        );
+
+        var countdownEvent = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            _logger.LogInformation("Got message: {Message}", msg.Data);
+            countdownEvent.Signal();
+        }, TestCancellationToken);
+
+        // Act
+        await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+        await countdownEvent.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Give the consumer time to reach end of partition after the message is consumed
+        await Task.Delay(TimeSpan.FromSeconds(1), TestCancellationToken);
+
+        // Assert
+        Assert.Equal(0, countdownEvent.CurrentCount);
+        var errorEntries = Log.LogEntries.Where(e => e.LogLevel == LogLevel.Error).ToList();
+        Assert.Empty(errorEntries);
+
+        await CleanupMessageBusAsync(messageBus);
     }
 }


### PR DESCRIPTION
## Summary

Upgrades Confluent.Kafka from 2.14.2 to the latest 2.15.0 release and fixes a real EOF-handling bug that the release's upgrade notes call out.

## Changes

- **Bump Confluent.Kafka** 2.14.2 → 2.15.0 in src/Foundatio.Kafka/Foundatio.Kafka.csproj
- **Fix EOF bug**: Skip IsPartitionEOF consume results in the listening loop before dispatch to OnMessageAsync, preventing NullReferenceException and invalid Commit/StoreOffset calls on empty results (Confluent.Kafka 2.15.0 now throws InvalidOperationException for this scenario)
- **Remove stale comment**: Removed misleading TODO on DeliveryReportFields (verified empirically that valid values work fine)
- **Add regression test**: CanReceiveMessagesWithPartitionEofEnabledAsync exercises the fix with EnablePartitionEof(true) and asserts no error log entries

## Test plan

- Build succeeds on both net8.0 and net10.0 targets (0 warnings/errors)
- Full test suite passes (37/37 tests)
- New test verified to fail without the EOF-skip fix (reproduces exact errors from 2.15.0 changelog)
- New test passes with the fix in place